### PR TITLE
Use coveralls to show code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
         run: |
           source .venv/bin/activate
           gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
-            --xml-pretty --exclude '.*/test/.*' -o coverage.xml
+            --xml-pretty --exclude ${TRICK_HOME}/ --exclude ${JEOD_HOME}/ \
+            --exclude '.*/test/.*' -o coverage.xml
 
       - name: Upload coverage report
         # Temporarily commented-out for testing:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,102 +37,99 @@ jobs:
             python3-devel diffutils
           dnf config-manager --enable powertools
           dnf install -y gtest-devel gmock-devel
-          update-ca-trust extract
 
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: debug
-        run: ls /etc/pki/tls/cert.pem
+      - name: Configure environment
+        run: |
+          echo "MAKEFLAGS=-j$(nproc)" >> "$GITHUB_ENV"
+          echo "CML_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          echo "TRICK_HOME=$GITHUB_WORKSPACE/externals/trick" >> "$GITHUB_ENV"
+          echo "JEOD_HOME=$GITHUB_WORKSPACE/externals/jeod" >> "$GITHUB_ENV"
+          if [[ "${{ github.event_name }}" != "pull_request" || \
+                "${{ github.event.pull_request.draft }}" == "false" ]]; then
+            echo "RUN_VERIF_SIMS=true" >> "$GITHUB_ENV"
+          else
+            echo "RUN_VERIF_SIMS=false" >> "$GITHUB_ENV"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          echo "SSL_CERT_FILE=/etc/pki/tls/cert.pem" >> "$GITHUB_ENV"
 
-#      - name: Configure environment
-#        run: |
-#          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-#          echo "MAKEFLAGS=-j$(nproc)" >> "$GITHUB_ENV"
-#          echo "CML_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-#          echo "TRICK_HOME=$GITHUB_WORKSPACE/externals/trick" >> "$GITHUB_ENV"
-#          echo "JEOD_HOME=$GITHUB_WORKSPACE/externals/jeod" >> "$GITHUB_ENV"
-#          if [[ "${{ github.event_name }}" != "pull_request" || \
-#                "${{ github.event.pull_request.draft }}" == "false" ]]; then
-#            echo "RUN_VERIF_SIMS=true" >> "$GITHUB_ENV"
-#          else
-#            echo "RUN_VERIF_SIMS=false" >> "$GITHUB_ENV"
-#          fi
-#
-#      - name: Set up Python virtual environment
-#        run: |
-#          python3 -m venv .venv
-#          source .venv/bin/activate
-#          pip3 install --upgrade pip
-#          pip3 install -r requirements.txt
-#
-#      - name: Build Trick
-#        uses: ./.github/actions/build-trick
-#        with:
-#          trick-home: ${{ env.TRICK_HOME }}
-#          trick-version: 25.0.2
-#
-#      - name: Build JEOD
-#        uses: ./.github/actions/build-jeod
-#        with:
-#          trick-home: ${{ env.TRICK_HOME }}
-#          jeod-home: ${{ env.JEOD_HOME }}
-#          jeod-version: jeod_v5.4.0
-#
-#      - name: Build CML and run unit tests
-#        run: |
-#          source .venv/bin/activate
-#          cmake --workflow --preset dev
-#
-#      - name: Build verification sims
-#        id: build_verif_sims
-#        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-#        run: |
-#          export PATH=${TRICK_HOME}/bin:${PATH}
-#          source .venv/bin/activate
-#          ./bin/test.py builds --quiet
-#
-#      - name: Run verification sims
-#        id: run_verif_sims
-#        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-#        run: |
-#          source .venv/bin/activate
-#          ./bin/test.py runs --quiet
-#
-#      - name: Compare verification data
-#        id: compare_verif_sim_data
-#        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-#        run: |
-#          source .venv/bin/activate
-#          ./bin/test.py comparisons --quiet
-#
-#      - name: Generate coverage report
-#        # Temporarily commented-out for testing:
-#        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-#        run: |
-#          source .venv/bin/activate
-#          gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
-#            --xml-pretty --exclude '.*/test/.*' -o coverage.xml
-#
-#      - name: Upload coverage report
-#        # Temporarily commented-out for testing:
-#        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-#        uses: coverallsapp/github-action@v2
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          file: coverage.xml
-#          format: cobertura
-#
-#      - name: Upload logs on failure
-#        if: >-
-#          ${{ failure() && env.RUN_VERIF_SIMS == 'true' && (
-#            steps.build_verif_sims.outcome == 'failure' ||
-#            steps.run_verif_sims.outcome == 'failure' ||
-#            steps.compare_verif_sim_data.outcome == 'failure'
-#          ) }}
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: verif-sim-failure-logs
-#          path: bin/logs/*.txt
-#          if-no-files-found: warn
-#          retention-days: 2
+      - name: Set up Python virtual environment
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip3 install --upgrade pip
+          pip3 install -r requirements.txt
+
+      - name: Build Trick
+        uses: ./.github/actions/build-trick
+        with:
+          trick-home: ${{ env.TRICK_HOME }}
+          trick-version: 25.0.2
+
+      - name: Build JEOD
+        uses: ./.github/actions/build-jeod
+        with:
+          trick-home: ${{ env.TRICK_HOME }}
+          jeod-home: ${{ env.JEOD_HOME }}
+          jeod-version: jeod_v5.4.0
+
+      - name: Build CML and run unit tests
+        run: |
+          source .venv/bin/activate
+          cmake --workflow --preset dev
+
+      - name: Build verification sims
+        id: build_verif_sims
+        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        run: |
+          export PATH=${TRICK_HOME}/bin:${PATH}
+          source .venv/bin/activate
+          ./bin/test.py builds --quiet
+
+      - name: Run verification sims
+        id: run_verif_sims
+        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        run: |
+          source .venv/bin/activate
+          ./bin/test.py runs --quiet
+
+      - name: Compare verification data
+        id: compare_verif_sim_data
+        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        run: |
+          source .venv/bin/activate
+          ./bin/test.py comparisons --quiet
+
+      - name: Generate coverage report
+        # Temporarily commented-out for testing:
+        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        run: |
+          source .venv/bin/activate
+          gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
+            --xml-pretty --exclude '.*/test/.*' -o coverage.xml
+
+      - name: Upload coverage report
+        # Temporarily commented-out for testing:
+        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml
+          format: cobertura
+
+      - name: Upload logs on failure
+        if: >-
+          ${{ failure() && env.RUN_VERIF_SIMS == 'true' && (
+            steps.build_verif_sims.outcome == 'failure' ||
+            steps.run_verif_sims.outcome == 'failure' ||
+            steps.compare_verif_sim_data.outcome == 'failure'
+          ) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: verif-sim-failure-logs
+          path: bin/logs/*.txt
+          if-no-files-found: warn
+          retention-days: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,21 @@ jobs:
         run: |
           dnf install -y epel-release
           dnf update -y
-          dnf install -y bison clang flex git llvm make maven swig cmake clang-devel \
+          dnf install -y ca-certificates  bison clang flex git llvm make maven swig cmake clang-devel \
             gcc gcc-c++ java-11-openjdk-devel libxml2-devel llvm-devel llvm-static \
             ncurses-devel openmotif openmotif-devel perl perl-Digest-MD5 udunits2 \
             udunits2-devel which zlib-devel libX11-devel libXt-devel \
             python3-devel diffutils
           dnf config-manager --enable powertools
           dnf install -y gtest-devel gmock-devel
+          update-ca-trust extract
 
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Configure environment
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           echo "MAKEFLAGS=-j$(nproc)" >> "$GITHUB_ENV"
           echo "CML_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
           echo "TRICK_HOME=$GITHUB_WORKSPACE/externals/trick" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,21 @@ jobs:
           ./bin/test.py comparisons --quiet
 
       - name: Generate coverage report
-        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        # Temporarily commented-out for testing:
+        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
         run: |
           source .venv/bin/activate
           gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
             --xml-pretty --exclude '.*/test/.*' -o coverage.xml
+
+      - name: Upload coverage report
+        # Temporarily commented-out for testing:
+        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml
+          format: cobertura
 
       - name: Upload logs on failure
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,7 @@ jobs:
           ./bin/test.py comparisons --quiet
 
       - name: Generate coverage report
-        # Temporarily commented-out for testing:
-        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
         run: |
           source .venv/bin/activate
           gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
@@ -113,8 +112,7 @@ jobs:
             --exclude '.*/test/.*' -o coverage.xml
 
       - name: Upload coverage report
-        # Temporarily commented-out for testing:
-        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           dnf install -y epel-release
           dnf update -y
-          dnf install -y ca-certificates  bison clang flex git llvm make maven swig cmake clang-devel \
+          dnf install -y bison clang flex git llvm make maven swig cmake clang-devel \
             gcc gcc-c++ java-11-openjdk-devel libxml2-devel llvm-devel llvm-static \
             ncurses-devel openmotif openmotif-devel perl perl-Digest-MD5 udunits2 \
             udunits2-devel which zlib-devel libX11-devel libXt-devel \
@@ -42,94 +42,97 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure environment
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          echo "MAKEFLAGS=-j$(nproc)" >> "$GITHUB_ENV"
-          echo "CML_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-          echo "TRICK_HOME=$GITHUB_WORKSPACE/externals/trick" >> "$GITHUB_ENV"
-          echo "JEOD_HOME=$GITHUB_WORKSPACE/externals/jeod" >> "$GITHUB_ENV"
-          if [[ "${{ github.event_name }}" != "pull_request" || \
-                "${{ github.event.pull_request.draft }}" == "false" ]]; then
-            echo "RUN_VERIF_SIMS=true" >> "$GITHUB_ENV"
-          else
-            echo "RUN_VERIF_SIMS=false" >> "$GITHUB_ENV"
-          fi
+      - name: debug
+        run: ls /etc/pki/tls/cert.pem
 
-      - name: Set up Python virtual environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip3 install --upgrade pip
-          pip3 install -r requirements.txt
-
-      - name: Build Trick
-        uses: ./.github/actions/build-trick
-        with:
-          trick-home: ${{ env.TRICK_HOME }}
-          trick-version: 25.0.2
-
-      - name: Build JEOD
-        uses: ./.github/actions/build-jeod
-        with:
-          trick-home: ${{ env.TRICK_HOME }}
-          jeod-home: ${{ env.JEOD_HOME }}
-          jeod-version: jeod_v5.4.0
-
-      - name: Build CML and run unit tests
-        run: |
-          source .venv/bin/activate
-          cmake --workflow --preset dev
-
-      - name: Build verification sims
-        id: build_verif_sims
-        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-        run: |
-          export PATH=${TRICK_HOME}/bin:${PATH}
-          source .venv/bin/activate
-          ./bin/test.py builds --quiet
-
-      - name: Run verification sims
-        id: run_verif_sims
-        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-        run: |
-          source .venv/bin/activate
-          ./bin/test.py runs --quiet
-
-      - name: Compare verification data
-        id: compare_verif_sim_data
-        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-        run: |
-          source .venv/bin/activate
-          ./bin/test.py comparisons --quiet
-
-      - name: Generate coverage report
-        # Temporarily commented-out for testing:
-        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-        run: |
-          source .venv/bin/activate
-          gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
-            --xml-pretty --exclude '.*/test/.*' -o coverage.xml
-
-      - name: Upload coverage report
-        # Temporarily commented-out for testing:
-        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage.xml
-          format: cobertura
-
-      - name: Upload logs on failure
-        if: >-
-          ${{ failure() && env.RUN_VERIF_SIMS == 'true' && (
-            steps.build_verif_sims.outcome == 'failure' ||
-            steps.run_verif_sims.outcome == 'failure' ||
-            steps.compare_verif_sim_data.outcome == 'failure'
-          ) }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: verif-sim-failure-logs
-          path: bin/logs/*.txt
-          if-no-files-found: warn
-          retention-days: 2
+#      - name: Configure environment
+#        run: |
+#          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+#          echo "MAKEFLAGS=-j$(nproc)" >> "$GITHUB_ENV"
+#          echo "CML_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+#          echo "TRICK_HOME=$GITHUB_WORKSPACE/externals/trick" >> "$GITHUB_ENV"
+#          echo "JEOD_HOME=$GITHUB_WORKSPACE/externals/jeod" >> "$GITHUB_ENV"
+#          if [[ "${{ github.event_name }}" != "pull_request" || \
+#                "${{ github.event.pull_request.draft }}" == "false" ]]; then
+#            echo "RUN_VERIF_SIMS=true" >> "$GITHUB_ENV"
+#          else
+#            echo "RUN_VERIF_SIMS=false" >> "$GITHUB_ENV"
+#          fi
+#
+#      - name: Set up Python virtual environment
+#        run: |
+#          python3 -m venv .venv
+#          source .venv/bin/activate
+#          pip3 install --upgrade pip
+#          pip3 install -r requirements.txt
+#
+#      - name: Build Trick
+#        uses: ./.github/actions/build-trick
+#        with:
+#          trick-home: ${{ env.TRICK_HOME }}
+#          trick-version: 25.0.2
+#
+#      - name: Build JEOD
+#        uses: ./.github/actions/build-jeod
+#        with:
+#          trick-home: ${{ env.TRICK_HOME }}
+#          jeod-home: ${{ env.JEOD_HOME }}
+#          jeod-version: jeod_v5.4.0
+#
+#      - name: Build CML and run unit tests
+#        run: |
+#          source .venv/bin/activate
+#          cmake --workflow --preset dev
+#
+#      - name: Build verification sims
+#        id: build_verif_sims
+#        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+#        run: |
+#          export PATH=${TRICK_HOME}/bin:${PATH}
+#          source .venv/bin/activate
+#          ./bin/test.py builds --quiet
+#
+#      - name: Run verification sims
+#        id: run_verif_sims
+#        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+#        run: |
+#          source .venv/bin/activate
+#          ./bin/test.py runs --quiet
+#
+#      - name: Compare verification data
+#        id: compare_verif_sim_data
+#        if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+#        run: |
+#          source .venv/bin/activate
+#          ./bin/test.py comparisons --quiet
+#
+#      - name: Generate coverage report
+#        # Temporarily commented-out for testing:
+#        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+#        run: |
+#          source .venv/bin/activate
+#          gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
+#            --xml-pretty --exclude '.*/test/.*' -o coverage.xml
+#
+#      - name: Upload coverage report
+#        # Temporarily commented-out for testing:
+#        #if: ${{ env.RUN_VERIF_SIMS == 'true' }}
+#        uses: coverallsapp/github-action@v2
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          file: coverage.xml
+#          format: cobertura
+#
+#      - name: Upload logs on failure
+#        if: >-
+#          ${{ failure() && env.RUN_VERIF_SIMS == 'true' && (
+#            steps.build_verif_sims.outcome == 'failure' ||
+#            steps.run_verif_sims.outcome == 'failure' ||
+#            steps.compare_verif_sim_data.outcome == 'failure'
+#          ) }}
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: verif-sim-failure-logs
+#          path: bin/logs/*.txt
+#          if-no-files-found: warn
+#          retention-days: 2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Welcome to the Common Model Library
+<h2 align="center">The Common Model Library</h2>
+
+<p align="center">
+<a href="https://coveralls.io/github/nasa/cml?branch=main"><img alt="Code coverage" src="https://coveralls.io/repos/github/nasa/cml/badge.svg?branch=main"></a>
+<a href="https://github.com/nasa/cml/actions/workflows/ci.yml"><img alt="Continuous integration status" src="https://github.com/nasa/cml/actions/workflows/ci.yml/badge.svg"></a>
+</p>
 
 The Common Model Library (CML) is designed to be a common location to store and share Trick-based and JEOD-based models that have common applicability to multiple simulations in the NASA community. The origin of the CML project is currently located here: https://github.com/nasa/cml
 


### PR DESCRIPTION
Add code coverage reporting to the CI workflow. We're using Coveralls because Trick uses it, and it seems to work well for them.

Closes #22 