### PR TITLE
Add sanitizers to developer build

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,7 +1,7 @@
 export CML_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export CTEST_PARALLEL_LEVEL=10
 export LSAN_OPTIONS="suppressions=${CML_HOME}/utility/sanitizers/lsan.supp"
-export ASAN_OPTIONS="fast_unwind_on_malloc=0:alloc_dealloc_mismatch=0:suppressions=${CML_HOME}/utility/sanitizers/asan.supp"
+export ASAN_OPTIONS="fast_unwind_on_malloc=0:suppressions=${CML_HOME}/utility/sanitizers/asan.supp"
 
 venv="${CML_HOME}/.venv/bin/activate"
 if [ -f "$venv" ]; then

--- a/.bashrc
+++ b/.bashrc
@@ -1,7 +1,7 @@
 export CML_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export CTEST_PARALLEL_LEVEL=10
+export ASAN_OPTIONS="suppressions=${CML_HOME}/utility/sanitizers/asan.supp"
 export LSAN_OPTIONS="suppressions=${CML_HOME}/utility/sanitizers/lsan.supp"
-export ASAN_OPTIONS="fast_unwind_on_malloc=0:suppressions=${CML_HOME}/utility/sanitizers/asan.supp"
 
 venv="${CML_HOME}/.venv/bin/activate"
 if [ -f "$venv" ]; then

--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,7 @@
 export CML_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export CTEST_PARALLEL_LEVEL=10
+export LSAN_OPTIONS="suppressions=${CML_HOME}/utility/sanitizers/lsan.supp"
+export ASAN_OPTIONS="fast_unwind_on_malloc=0:alloc_dealloc_mismatch=0:suppressions=${CML_HOME}/utility/sanitizers/asan.supp"
 
 venv="${CML_HOME}/.venv/bin/activate"
 if [ -f "$venv" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             udunits2-devel which zlib-devel libX11-devel libXt-devel \
             python3-devel diffutils
           dnf config-manager --enable powertools
-          dnf install -y gtest-devel gmock-devel liblsan libubsan
+          dnf install -y gtest-devel gmock-devel libasan liblsan libubsan
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             udunits2-devel which zlib-devel libX11-devel libXt-devel \
             python3-devel diffutils
           dnf config-manager --enable powertools
-          dnf install -y gtest-devel gmock-devel
+          dnf install -y gtest-devel gmock-devel liblsan libubsan
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build CML and run unit tests
         run: |
-          source .venv/bin/activate
+          source .bashrc
           cmake --workflow --preset dev
 
       - name: Build verification sims
@@ -86,27 +86,27 @@ jobs:
         if: ${{ env.RUN_VERIF_SIMS == 'true' }}
         run: |
           export PATH=${TRICK_HOME}/bin:${PATH}
-          source .venv/bin/activate
+          source .bashrc
           ./bin/test.py builds --quiet
 
       - name: Run verification sims
         id: run_verif_sims
         if: ${{ env.RUN_VERIF_SIMS == 'true' }}
         run: |
-          source .venv/bin/activate
+          source .bashrc
           ./bin/test.py runs --quiet
 
       - name: Compare verification data
         id: compare_verif_sim_data
         if: ${{ env.RUN_VERIF_SIMS == 'true' }}
         run: |
-          source .venv/bin/activate
+          source .bashrc
           ./bin/test.py comparisons --quiet
 
       - name: Generate coverage report
         if: ${{ env.RUN_VERIF_SIMS == 'true' }}
         run: |
-          source .venv/bin/activate
+          source .bashrc
           gcovr -r . --exclude-unreachable-branches --exclude-throw-branches \
             --xml-pretty --exclude ${TRICK_HOME}/ --exclude ${JEOD_HOME}/ \
             --exclude '.*/test/.*' -o coverage.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ option(CML_CODE_COVERAGE "Instrument the build to enable coverage profiling." OF
 
 option(CML_WARNINGS_AS_ERRORS "Treat all compiler warnings as errors." OFF)
 
+option(CML_USE_SANITIZERS
+"Build with address sanitizer and undefined behavior sanitizer." OFF)
+
 # ---------------------------------------------------------------------------- #
 # Locate common CML dependencies:                                              #
 #                                                                              #
@@ -115,12 +118,15 @@ endforeach()
 target_link_libraries(cml_static
     PUBLIC
         LibXml2::LibXml2
+    INTERFACE
+        $<$<BOOL:${CML_USE_SANITIZERS}>:-fsanitize=address,undefined>
     PRIVATE
         $<$<BOOL:${CML_CODE_COVERAGE}>:--coverage>
 )
 target_link_libraries(cml_shared
     PUBLIC
         LibXml2::LibXml2
+        $<$<BOOL:${CML_USE_SANITIZERS}>:-fsanitize=address,undefined>
     PRIVATE
         $<$<BOOL:${CML_CODE_COVERAGE}>:--coverage>
 )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,7 +40,8 @@
             "cacheVariables": {
                 "CML_BUILD_UNIT_TESTS": "OFF",
                 "CML_CODE_COVERAGE": "OFF",
-                "CML_WARNINGS_AS_ERRORS": "OFF"
+                "CML_WARNINGS_AS_ERRORS": "OFF",
+                "CML_USE_SANITIZERS": "OFF"
             }
         },
         {
@@ -50,7 +51,8 @@
             "cacheVariables": {
                 "CML_BUILD_UNIT_TESTS": "ON",
                 "CML_CODE_COVERAGE": "ON",
-                "CML_WARNINGS_AS_ERRORS": "ON"
+                "CML_WARNINGS_AS_ERRORS": "ON",
+                "CML_USE_SANITIZERS": "ON"
             }
         },
         {

--- a/cmake/AddCMLLibrary.cmake
+++ b/cmake/AddCMLLibrary.cmake
@@ -53,6 +53,7 @@ function(add_cml_library)
             JEOD::JEOD
         PRIVATE
             $<$<BOOL:${CML_CODE_COVERAGE}>:--coverage>
+            $<$<BOOL:${CML_USE_SANITIZERS}>:-fsanitize=address,undefined>
     )
 
     target_compile_features(${LIBRARY_NAME}
@@ -61,12 +62,13 @@ function(add_cml_library)
     )
 
     # Add warning flags. Instrument the build for code coverage if CML_CODE_COVERAGE
-    # is true.
+    # is true and sanitizing if CML_USE_SANITIZERS is true.
     target_compile_options(${LIBRARY_NAME}
         PRIVATE
             -Wall
             -Wextra
             $<$<BOOL:${CML_CODE_COVERAGE}>:--coverage>
+            $<$<BOOL:${CML_USE_SANITIZERS}>:-fsanitize=address,undefined>
     )
     if (CML_WARNINGS_AS_ERRORS)
         # TODO: Nino Tarantino 2/11/26: uncomment this as part of #24.

--- a/cmake/AddCMLTests.cmake
+++ b/cmake/AddCMLTests.cmake
@@ -40,11 +40,17 @@ function(add_cml_tests)
             JEOD::JEOD
             GTest::gtest_main
             GTest::gmock_main
+            $<$<BOOL:${CML_USE_SANITIZERS}>:-fsanitize=address,undefined>
     )
 
     target_compile_features(${TEST_NAME}
         PRIVATE
             cxx_std_17
+    )
+
+    target_compile_options(${TEST_NAME}
+        PRIVATE
+            $<$<BOOL:${CML_USE_SANITIZERS}>:-fsanitize=address,undefined>
     )
 
     include(GoogleTest)

--- a/mkspecs/internal/cml_unit_sim.mk
+++ b/mkspecs/internal/cml_unit_sim.mk
@@ -15,4 +15,9 @@ TRICK_CFLAGS += -g -I. -Wall -Wextra -Werror -Wno-implicit-fallthrough -Wno-form
 TRICK_CXXFLAGS += -g -I. -std=c++17 -Wall -Wextra -Werror -Wno-implicit-fallthrough -Wno-format-truncation -Wno-int-in-bool-context -Wno-address -Wno-nonnull-compare
 TRICK_SFLAGS += -I${JEOD_HOME}/lib/jeod/JEOD_S_modules -I.
 
+# Sanitizer options for unit sims.
+TRICK_CFLAGS += -fsanitize=address,undefined
+TRICK_CXXFLAGS += -fsanitize=address,undefined
+TRICK_LDFLAGS += -fsanitize=address,undefined
+
 TRICK_CXXFLAGS += -I${JEOD_HOME}/..

--- a/models/utilities/fault_management/src/fault_manager.cc
+++ b/models/utilities/fault_management/src/fault_manager.cc
@@ -345,6 +345,8 @@ void FaultManager::parse() {
   // Note -- the fault_param_cache and trigger_value_cache pending assignments
   // are cleared in initialize() after this method has returned and after the
   // individual faults have been initialized.
+
+  xmlFreeDoc(doc);
 }
 
 

--- a/models/utilities/table_interp_cpp/src/generic_multi_input_table.cc
+++ b/models/utilities/table_interp_cpp/src/generic_multi_input_table.cc
@@ -495,8 +495,6 @@ bool
 GenericMultiInputTable::generate_output()
 {
   // Run prechecks, abort output generation if prechecks fail.
-  // However, there does not appear to be a way to fail the prechecks, so this
-  // is a failsafe.
   if (!precheck_output()) {
     return false;
   }
@@ -553,6 +551,22 @@ GenericMultiInputTable::precheck_output()
       "Continuing runs the risk of accessing data out of bounds.\n"
       "Aborting table-lookup\n");
     return false;
+  }
+
+  // Check to make sure that if one of the independent variables had its data
+  // reloaded, the new data was the correct size. Otherwise, we may attempt to
+  // access data outside the storage of the table in generate_output().
+  const size_t num_independents = independents.size();
+  for (size_t ii = 0; ii < num_independents; ++ii) {
+    if (independents[ii].first->get_size() != size_of_dimension[ii + 1]) {
+      CMLMessage::error(
+        __FILE__,__LINE__,"Internal error:\n",
+        "The size of independent variable[",ii,"] (",
+        independents[ii].first->get_size(),") is inconsistent with the\n"
+        "size of dimension[",ii+1,"] (",
+        size_of_dimension[ii + 1],") of the data table.\n");
+      return false;
+    }
   }
   return true;
 }

--- a/models/utilities/table_interp_cpp/src/table_independent_variable.cc
+++ b/models/utilities/table_interp_cpp/src/table_independent_variable.cc
@@ -11,6 +11,7 @@ PROGRAMMERS:
   )
 *******************************************************************************/
 
+#include <algorithm>
 #include <cmath> // floor
 #include "cml/models/utilities/math_utils/include/math_utils.hh"
 
@@ -581,15 +582,8 @@ TableIndependentVariable::generate_fraction()
   fraction = (modified_value - data[index])/(data[index+1]-data[index]);
 
   // Make sure the arithmetic kept fraction within [0.0,1.0]
-  // For these statements to be executed, the independent data
-  //    must have been modified externally or have been corrupted.
-  //    This is unlikely
-  if (fraction < 0.0) {
-    fraction = 0.0;
-  }
-  else if (fraction > 1.0) {
-    fraction = 1.0;
-  }
+  fraction = std::clamp(fraction, 0.0, 1.0);
+
   // To support the discrete LookupMethods, check for proximity to a calibrated
   // point.  When variable is close to a calibrated point, PREV, NEXT, FLOOR,
   // CEIL should all take that point.  ROUND also does, but that is handled as

--- a/models/utilities/xml_helper/verif/SIM_verif/include/test.hh
+++ b/models/utilities/xml_helper/verif/SIM_verif/include/test.hh
@@ -205,6 +205,8 @@ struct XmlHelperTester {
     }
 
     std::cout << "**********************************************************\n";
+
+    xmlFreeDoc(xml_file);
   }
 
 

--- a/utility/sanitizers/asan.supp
+++ b/utility/sanitizers/asan.supp
@@ -1,0 +1,1 @@
+# No address sanitizer suppressions at the moment.

--- a/utility/sanitizers/lsan.supp
+++ b/utility/sanitizers/lsan.supp
@@ -1,0 +1,10 @@
+# Ignore any leaks coming from Trick that we can't control.
+leak:Trick::DataRecordGroup::DataRecordGroup
+leak:Trick::FrameLog::default_data
+leak:Trick::MemoryManager::ref_attributes
+leak:Trick::MulticastGroup::MulticastGroup
+leak:Trick::UnitsMap::add_param
+leak:Trick::VariableServerListenThread::thread_body
+
+# Ignore any leaks coming from the libpython external library.
+leak:libpython*.so

--- a/utility/sanitizers/lsan.supp
+++ b/utility/sanitizers/lsan.supp
@@ -6,5 +6,12 @@ leak:Trick::MulticastGroup::MulticastGroup
 leak:Trick::UnitsMap::add_param
 leak:Trick::VariableServerListenThread::thread_body
 
-# Ignore any leaks coming from the libpython external library.
-leak:libpython*.so
+# Ignore any leaks coming from Python and SWIG.
+leak:libpython*
+leak:SWIG*
+leak:Swig*
+leak:*numpy*
+
+# Ignore other leaks that we can't do anything about.
+leak:vasprintf
+leak:libudunits*


### PR DESCRIPTION
Instrument the developer build with address sanitizer and undefined behavior sanitizer. This PR also fixes issues identified when running unit tests and verification sims with the sanitizers enabled.

Luckily, the sanitizers don't have nearly as noticeable a hit to performance as `valgrind`, but we will notice a hit to our CI walltime regardless.

| | No sanitizers | With sanitizers | % increase with sanitizing |
|-----| -------------- | ---------------- | ---------------------------- |
| **Sim builds** | 22.5 minutes  | 33.0 minutes    | 47%                        |
| **Sim runs**   | 11.0 minutes  | 22.75 minutes   | 107%                       |

In the future we're going to de-prioritize unit sim testing for many models and transition to GoogleTest, which will more than balance out the hit we're seeing here.

Closes #33