### PR TITLE
Remove the JEOD NamedItem ostream interface

### DIFF
--- a/models/dynamics/actions/mass_body_detach_impulsive/src/mass_body_detach_impulsive.cc
+++ b/models/dynamics/actions/mass_body_detach_impulsive/src/mass_body_detach_impulsive.cc
@@ -83,8 +83,8 @@ MassBodyDetachImpulsive::apply( jeod::DynManager & dyn_manager)
   if (parent == NULL) {
     CMLMessage::error (
       __FILE__, __LINE__, jeod::BodyActionMessages::not_performed,
-       "\n", action_identifier, " failed to detach ", subject->name, " because no parent body was found to\n"
-      "which ", subject->name, " is currently attached.");
+       "\n", action_identifier, " failed to detach ", subject->name.get_name(), " because no parent body was found to\n"
+      "which ", subject->name.get_name(), " is currently attached.");
 
     if (terminate_on_error) {
       CMLMessage::fail (
@@ -99,7 +99,7 @@ MassBodyDetachImpulsive::apply( jeod::DynManager & dyn_manager)
     // Detachment failed: Terminate the sim if terminate_on_error is set.
     CMLMessage::error (
       __FILE__, __LINE__, jeod::BodyActionMessages::not_performed,
-      "\n", action_identifier, " failed to detach ", subject->name, ".");
+      "\n", action_identifier, " failed to detach ", subject->name.get_name(), ".");
 
 
     if (terminate_on_error) {
@@ -117,7 +117,7 @@ MassBodyDetachImpulsive::apply( jeod::DynManager & dyn_manager)
   // down are unaffected.
   CMLMessage::debug (
     __FILE__, __LINE__, jeod::BodyActionMessages::trace,
-     "\n", action_identifier, ": ", subject->name, " detached.");
+     "\n", action_identifier, ": ", subject->name.get_name(), " detached.");
 
   jeod::DynBody  * parent_body  = parent->dyn_owner;
   jeod::DynBody  * subject_body = get_subject_dyn_body();
@@ -172,7 +172,7 @@ MassBodyDetachImpulsive::apply_impulse( jeod::DynBody          & dyn_body,
   if (mass_point == NULL) {
     CMLMessage::error (
       __FILE__, __LINE__, jeod::BodyActionMessages::not_performed,
-       "\n", action_identifier, " could not find mass point named ", mass_point_name, " on body ", dyn_body.name, " to apply impulse to."
+       "\n", action_identifier, " could not find mass point named ", mass_point_name, " on body ", dyn_body.name.get_name(), " to apply impulse to."
       "\nNo impulse applied to this body.");
 
     if (terminate_on_error) {
@@ -240,7 +240,7 @@ MassBodyDetachImpulsive::apply_impulse( jeod::DynBody          & dyn_body,
     if (root_body == NULL) {
       CMLMessage::error (
         __FILE__, __LINE__, jeod::BodyActionMessages::not_performed,
-         "\n", action_identifier, " could not find root body for body ", dyn_body.name, ".\n"
+         "\n", action_identifier, " could not find root body for body ", dyn_body.name.get_name(), ".\n"
         "Impulse must be applied to root body.\n"
         "No impulse applied to this body.");
       if (terminate_on_error) {

--- a/models/dynamics/mass/dynamic_mass/src/dynamic_mass_group.cc
+++ b/models/dynamics/mass/dynamic_mass/src/dynamic_mass_group.cc
@@ -465,10 +465,10 @@ DynamicMassGroup::test_root_body()
           "There are multiple root bodies branching from the same Group.\n"
           "DynamicMassGroups must stay as one block in "
           "order for their updates to work.\n"
-          "Body called ", dyn_masses[0]->name, " has a root called ",
-          first_root->name, " while\n", "body called ",
-          dyn_masses[ii]->name, " has a root called ",
-          second_root->name, "");
+          "Body called ", dyn_masses[0]->name.get_name(), " has a root called ",
+          first_root->name.get_name(), " while\n", "body called ",
+          dyn_masses[ii]->name.get_name(), " has a root called ",
+          second_root->name.get_name(), "");
       }
     }
     root_body_ptr = const_cast<jeod::MassBody*>(first_root);
@@ -509,7 +509,7 @@ DynamicMassGroup::add_mass_to_group_internal(
       if (send_err_msg) {
         CMLMessage::error(
           __FILE__,__LINE__,"Invalid object addition\n",
-          "Attempt to add a new DynamicMassBody (", mass->name, ") that is already assigned\n"
+          "Attempt to add a new DynamicMassBody (", mass->name.get_name(), ") that is already assigned\n"
           "to this group. \n"
           "Cannot duplicate a mass-body in a single group.\n");
       }

--- a/models/dynamics/mass/dynamic_mass/src/dynamic_mass_string.cc
+++ b/models/dynamics/mass/dynamic_mass/src/dynamic_mass_string.cc
@@ -189,7 +189,7 @@ void DynamicMassString::add_mass_to_string( // Return: -- void
     if (new_mass_body == (*it)) {
       CMLMessage::error(
         __FILE__,__LINE__,"Invalid object addition\n",
-        "Attempt to add a new DynamicMassBody (", new_mass_body->name, ") that is already assigned\n"
+        "Attempt to add a new DynamicMassBody (", new_mass_body->name.get_name(), ") that is already assigned\n"
         "to this string. \n"
         "Cannot duplicate a mass-body on a single string.\n");
       return;

--- a/models/dynamics/mass/mass_body_distribute_comp_to_core/src/mass_body_distribute_comp_to_core.cc
+++ b/models/dynamics/mass/mass_body_distribute_comp_to_core/src/mass_body_distribute_comp_to_core.cc
@@ -43,10 +43,10 @@ MassBodyDistributeCompToCore::check_configuration()
   if ( !adjustable_body.is_progeny_of(target_body)) {
     CMLMessage::error(
       __FILE__,__LINE__,"Invalid adjustments in Mass Tree\n",
-      "The adjustable-body (", adjustable_body.name, ") is not a progeny of\n"
-      "the target body (", target_body.name, ").\n"
-      "Consequently, adjusting the mass properties of ", adjustable_body.name,
-      "\ncannnot affect the composite-properties of ", target_body.name, ".\n"
+      "The adjustable-body (", adjustable_body.name.get_name(), ") is not a progeny of\n"
+      "the target body (", target_body.name.get_name(), ").\n"
+      "Consequently, adjusting the mass properties of ", adjustable_body.name.get_name(),
+      "\ncannnot affect the composite-properties of ", target_body.name.get_name(), ".\n"
       "Aborting adjustment.\n");
     return false;
   }
@@ -308,8 +308,8 @@ MassBodyDistributeCompToCore::check_for_valid_mass_properties()
   // If any error message is generated, this will be the beginning of it
   std::ostringstream err_msg;
   err_msg << "It is physically impossible to achieve specified composite mass\n"
-    << "properties of " << target_body.name << " by changing the core mass\n"
-    << "properties of " << adjustable_body.name << ":\n";
+    << "properties of " << target_body.name.get_name() << " by changing the core mass\n"
+    << "properties of " << adjustable_body.name.get_name() << ":\n";
   bool mass_invalid = false;
   if (adjustable_body.core_properties.mass <= 0.0) {
      err_msg << "* The mass would have a non-positive value of "
@@ -342,7 +342,7 @@ MassBodyDistributeCompToCore::check_for_valid_mass_properties()
       CMLMessage::error(__FILE__, __LINE__,
         "Invalid mass properties resulting from MassBodyDistributeCompToCore\n",
          err_msg.str(), "Because the fail_if_mass_invalid flag has been set to false, the\n"
-        "simulation will continue with impossible mass properties for ", adjustable_body.name, ".\n");
+        "simulation will continue with impossible mass properties for ", adjustable_body.name.get_name(), ".\n");
     }
   }
 }

--- a/models/dynamics/state_descriptors/atmos_rel_state/src/atmos_relative_state.cc
+++ b/models/dynamics/state_descriptors/atmos_rel_state/src/atmos_relative_state.cc
@@ -622,7 +622,7 @@ AtmosRelativeState::compute_reynolds_number()
       __FILE__, __LINE__, "Atmosphere Relative State Setup error\n",
       "Computation of Reynolds Number requires a reference length, which "
       "has not been assigned.\n"
-      "Reynolds number for vehicle ", body.name, " will not be computed.\n"
+      "Reynolds number for vehicle ", body.name.get_name(), " will not be computed.\n"
       "Use method AtmosRelativeState::set_reference_length( double *)\n"
       "to set this pointer.\n"
       "This message will only be sent once.\n");

--- a/models/dynamics/state_descriptors/separation_state/src/lvlh_separation_state.cc
+++ b/models/dynamics/state_descriptors/separation_state/src/lvlh_separation_state.cc
@@ -91,7 +91,7 @@ LvlhSeparationState::initialize( jeod::DynManager & dyn_manager,
   if (subject_frame == nullptr) {
     CMLMessage::error(
       __FILE__,__LINE__,"Invalid frame name\n",
-      "The specified frame-name '", subject_name, "' on body-name '", subject_body.name, "' could not be found\n"
+      "The specified frame-name '", subject_name, "' on body-name '", subject_body.name.get_name(), "' could not be found\n"
       "by the dynamics manager.\n"
       "Initialization of LvlhSeparationState failed because the\n"
       "SeparationState requires a defined subject frame before it can\n"
@@ -121,7 +121,7 @@ LvlhSeparationState::initialize( jeod::DynManager & dyn_manager,
   if (lvlh_origin_frame == nullptr) {
     CMLMessage::error(
       __FILE__,__LINE__,"Invalid frame name\n",
-      "The specified frame-name '", source_name, "' on body-name '", source_body.name, "' could not be found\n"
+      "The specified frame-name '", source_name, "' on body-name '", source_body.name.get_name(), "' could not be found\n"
       "by the dynamics manager.\n"
       "Initialization of LvlhSeparationState failed because the LvlhFrame\n"
       "requires this frame to construct the LVLH frame.\n");

--- a/models/dynamics/state_overrides/contact/src/contact_state_override.cc
+++ b/models/dynamics/state_overrides/contact/src/contact_state_override.cc
@@ -162,7 +162,7 @@ ContactStateOverride::override_state()
       CMLMessage::error(
         __FILE__,__LINE__,"Unidentified mass tree error\n"
         "The mass-tree returned a NULL pointer for the root of the tree\n"
-        "containing the override-body (", override_body.name,"(.\n"
+        "containing the override-body (", override_body.name.get_name(),"(.\n"
         "This should not happen.\n"
         "Aborting state override.\n");
       return;

--- a/models/environment/atmos/atmos_exec/src/atmosphere_exec.cc
+++ b/models/environment/atmos/atmos_exec/src/atmosphere_exec.cc
@@ -231,7 +231,7 @@ AtmosphereExec::initialize( // Return: --   Void
 
   CMLMessage::inform(
     __FILE__,__LINE__," Atmosphere Exec initialization configuration:\n",
-    "For vehicle ", body.name,
+    "For vehicle ", body.name.get_name(),
     ":\nAtmosphere: ", current_atmos->name,
     "\nWinds: ", current_winds->name,
     "\nTime: ", time_in.calendar_year, "/",

--- a/models/utilities/cml_message/include/cml_message.hh
+++ b/models/utilities/cml_message/include/cml_message.hh
@@ -234,9 +234,4 @@ class CMLMessage
   CMLMessage & operator= (const CMLMessage &);
 };
 
-#ifndef SWIG
-inline std::ostream& operator<<(std::ostream& os, const jeod::NamedItem& item) {
-    return os << item.get_name();
-}
-#endif
 #endif

--- a/models/vehicle_management/dummy_vehicle_launcher/src/dummy_vehicle_launcher.cc
+++ b/models/vehicle_management/dummy_vehicle_launcher/src/dummy_vehicle_launcher.cc
@@ -103,10 +103,10 @@ DummyVehicleLauncher::initialize_integ_group_actions()
     if (current_integ_group == NULL) {
       CMLMessage::warn (
         __FILE__, __LINE__, "VehicleLauncher::InitializationError\n",
-        "The initialization of the dummy-vehicle-launcher for vehicle ", body.name, ""
+        "The initialization of the dummy-vehicle-launcher for vehicle ", body.name.get_name(), ""
         "\ndoes not have a specified integ group. If you're not setting "
         "\nthe integ group at a later time, it will try to use the same "
-        "\ninteg group as ", real_state_body.name, ".\n");
+        "\ninteg group as ", real_state_body.name.get_name(), ".\n");
     }
     intended_integ_group = current_integ_group;
   }
@@ -285,7 +285,7 @@ DummyVehicleLauncher::add_to_integ_group()
       CMLMessage::error (
         __FILE__, __LINE__, "VehicleLauncher::StartupError\n",
         "The intended integration group was not specified.\n"
-        "Unable to add vehicle ", body.name, " to any integration group.\n"
+        "Unable to add vehicle ", body.name.get_name(), " to any integration group.\n"
         "It will not be integrated.\n");
         return;
     }
@@ -314,7 +314,7 @@ DummyVehicleLauncher::process_inconsistent_setup()
   if (current_integ_group == NULL) {
     CMLMessage::warn (
       __FILE__, __LINE__, "VehicleLauncher::StartupError\n",
-      "An intended integration group was specified, but the jeod::DynBody ", body.name, "\n"
+      "An intended integration group was specified, but the jeod::DynBody ", body.name.get_name(), "\n"
       "cannot be removed from its existing integration group.\n"
       "Ignoring specified values.\n");
     return;
@@ -325,7 +325,7 @@ DummyVehicleLauncher::process_inconsistent_setup()
     __FILE__, __LINE__, "VehicleLauncher::StartupError\n",
     "The automated integration group switching was not activated,\n"
     "but an intended integration group was specified.\n"
-    "Removing the jeod::DynBody ", body.name, " from its current integration group\n"
+    "Removing the jeod::DynBody ", body.name.get_name(), " from its current integration group\n"
     "and moving it to the specified integration group.\n");
   current_integ_group->delete_dyn_body( body );
   add_to_integ_group_at_launch = true;


### PR DESCRIPTION
During the conversion from JEOD 3.4 to JEOD 5, we defined an `operator<<` overload for `std::ostream` and `jeod::NamedIte`m. This was done to avoid the hassle of correcting a bunch of calls to message prints with `<item>.name` to `<item>.name.get_name()`. That was just a temporary fix though, because we shouldn't be adding operator overloads for types we don't own.

This commit removes that overloaded operator and fixes all places where we're trying to print a `jeod::NamedItem`.

Side note: JEOD is going to remove the `NamedItem` type in JEOD 6 anyways.

Closes #23