### PR TITLE
Remove duplicate binary files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The Common Model Library accepts new models and updates to existing models from NASA
 simulation-developing groups and any other groups to whom CML provides value. Before
-submitting changes, please look at our [coding standards](docs/CML_Coding_Standards.pdf)
+submitting changes, please look at our [coding standards](docs/CML_Coding_Standards.rst)
 in the `docs` folder. If you're using an older version of CML, please also double check
 that the changes you're proposing have not already been integrated into CML in a more
 recent release.
@@ -58,7 +58,7 @@ When submitting a new model to CML, you must provide:
 
 Models must meet NPR 7150.2 Class A, B, C, or D to be accepted into CML. Additionally,
 all new models must have unit tests which cover at least 90% of source code lines and
-must be submitted alongside documentation which adequately describes the model. See the [coding standards](docs/CML_Coding_Standards.pdf) for more information.
+must be submitted alongside documentation which adequately describes the model. See the [coding standards](docs/CML_Coding_Standards.rst) for more information.
 
 Models must also provide sufficient value to CML to be accepted. Trivial models which
 contain only a handful of lines of code can add a large maintenance burden to the CML team

--- a/docs/CML_Coding_Standards.docx
+++ b/docs/CML_Coding_Standards.docx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a258b78eab5dcb4d0bd93713e1c6595cc3736efcb8accff135c3b71510e7a34
-size 96548

--- a/docs/CML_Coding_Standards.pdf
+++ b/docs/CML_Coding_Standards.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc35c7fb0369f90f5091b1bf6445a0d15a66c9840a24a510405c2d6ab4039cdb
-size 343393

--- a/docs/CML_Coding_Standards.rst
+++ b/docs/CML_Coding_Standards.rst
@@ -1,0 +1,545 @@
+=============================================
+ Common Model Library (CML) Coding Standards
+=============================================
+
+.. list-table:: Revision History
+   :widths: 30 30 70
+
+   * - Identifier
+     - Release date
+     - Description
+   * - v0.1 (Baseline)
+     - 03/31/2026
+     - Initial CML coding standards
+   * - v0.2
+     - 07/21/2026
+     - Changed GitLab references to GitHub and converted to reStructuredText
+
+.. table::
+   :align: center
+   :width: 100%
+
+   +----------------+---------------+
+   | Prepared by    | Approved by   |
+   +================+===============+
+   | Nino Tarantino | Daniel Jordan |
+   |                |               |
+   | CML Maintainer | CML Lead      |
+   |                |               |
+   | 03/31/2026     | 03/31/2026    |
+   +----------------+---------------+
+
+.. contents:: Table of Contents
+
+Introduction
+============
+
+This document provides the formal code standards that are used within the Common Model Library (CML) team. The coding
+standards in this document are designed to protect the reliability, maintainability, and usability of the library while
+avoiding overly restrictive standards that may prevent some simulation teams from easily contributing their models to
+CML. These standards are written based on generally accepted best practices in industry as well as lessons learned from
+experienced developers in the Trick-based simulation field at NASA JSC. These standards are expected to mature and
+develop over time.
+
+Purpose
+-------
+
+Coding standards are used in large software development projects because they provide multiple benefits to the
+organization developing the software application. These benefits are seen as critical for the CML team developing and
+maintaining complex and high-fidelity time-domain simulation models used for spacecraft analysis.
+
+Scope
+-----
+
+The coding standards listed in this document apply only to the developed code associated with models under the control
+of the CML team. These coding standards do not apply to external packages such as Trick, JEOD, or any other third-party
+dependency.
+
+Change Authority/Responsibility
+-------------------------------
+
+Proposed changes to this document shall be submitted as a GitHub issue or via email to the CML team for consideration
+and disposition with the team lead.
+
+Applicable Documents
+--------------------
+
+The following documents include specifications, models, standards, guidelines, handbooks, and other special
+publications. The documents listed in this product are applicable to the extent specified herein.
+
+.. list-table::
+   :widths: 30 30 70
+   :header-rows: 1
+
+   * - Document Number
+     - Document Revision
+     - Document Title
+   * - NASA-STD-7009
+     - A.1
+     - Standard for Models and Simulations
+   * - NPR 7150.2
+     - C
+     - NASA Software Engineering Requirements
+
+Reference Documents
+-------------------
+
+The following documents contain supplemental information to guide the user in the application of this document.
+
+.. list-table::
+   :widths: 50 50 50
+
+   * - Document Number
+     - Document Revision
+     - Document Title
+   * -
+     -
+     -
+
+Coding Standards
+================
+
+This section describes the coding standards and how they apply to the software development workflow. The purpose of
+having coding standards is to ensure that a project's code base not only functions correctly but is also readable
+modifiable, and maintainable. The code that comes into the library must be easily reviewable and not threaten the
+stability of the library itself. With these goals in mind, the CML Coding Standards fall in two categories:
+
+-  `Model coding standards <Model Coding Standards_>`_ – These coding standards should be met upon a developer’s Pull
+   Request Review. These standards are intended to ensure the quality, stability, and cohesiveness of CML.
+   Non-compliances will be identified in the review and evaluated for risk to integration into the library.
+-  `Best practice coding standards <Best Practice Coding Standards_>`_ – These coding standards should be met as early as
+   possible but are not required to be met upon a developer’s Pull Request Review. These standards are intended to
+   ensure that the codebase follows modern best practices. Non-compliances will be evaluated for risk to the library and
+   documented in a follow-on GitHub issue for future resolution if necessary.
+
+Application and Enforcement
+---------------------------
+
+New models submitted to CML must first pass through a Pull Request Review. During the review, the submitting group
+provides CML with the NASA NPR 7150.2 classification of the model and evidence of NASA-STD-7009 compliance. The CML team
+will review the documentation provided and will check the models submitted for adherence to the coding standards. Many
+of the model coding standards are checked with assistance from automated tooling, which reduces the amount of manual
+review necessary.
+
+Updates to existing CML code will also be checked for adherence to the coding standards during a Pull Request Review.
+Unlike a new model submission, NPR 7150.2 and NASA-STD-7009 documentation is not required unless the model’s
+classification has changed.
+
+Model Coding Standards
+----------------------
+
+These standards cover the attributes of the source code required for CML models and must be met before acceptance of the
+source code into the main branch of the CML codebase.
+
+Model Coding Standards are broken into categories depending on the language used. CML-MCS-GENERAL standards apply to all
+code, regardless of language. CML-MCS-CPP standards apply to C++ code. CML-MCS-PYTHON standards apply to Python code.
+
+**CML-MCS-GENERAL-1**: All Trick-based simulation model code shall be written in the C++ programming language
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Trick simulation models should be written in C++. Other programming languages, such as C, are not allowed
+to be used for model implementation. Autocoded models from MATLAB or Simulink source are not considered to have been
+written in C++.
+
+**Enforcement**: Static analysis and Pull Request Review.
+
+**CML-MCS-GENERAL-2**: All scripts required to maintain model code must be committed at the time of Pull Request Review
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Some models may contain data or other content that was automatically generated by means of a script.
+These scripts must also be committed and live alongside the model so that the model may be properly maintained.
+
+**Enforcement**: Pull Request Review.
+
+**CML-MCS-GENERAL-3**: Source code shall not contain ITAR, EAR, or CUI data
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: CML is an open-source project and must not contain sensitive data.
+
+**Enforcement**: Pull Request Review.
+
+**CML-MCS-GENERAL-4**: Source code shall be formatted in accordance with a common stylesheet
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Consistent codebases are easier to use and maintain. Automated code formatting ensures that the git
+history contains only impactful changes to the code rather than formatting tweaks. The specific formatting
+enforcement tool and stylesheet may differ between languages.
+
+**Enforcement**: Static analysis operating off of a common stylesheet available to developers and users.
+
+**CML-MCS-GENERAL-5**: Commented-out code shall only be allowed when accompanied by an associated project issue, point of contact email address, and current date
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Commented-out code should be rare. When it is included in the codebase, there should be an expectation
+that the code will be un-commented or removed by a certain date.
+
+**Enforcement**: Pull Request Review.
+
+**Example**
+
+.. code-block:: cpp
+
+    // TODO jane.doe@nasa.gov 01/01/2000: uncomment when addressing issue #1.
+    //my_type.nonexistent_field = 1;
+
+**CML-MCS-CPP-1**: Source code shall live within the “cml” C++ namespace
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Namespaces prevent name collisions between CML-defined types and the types defined by consumers of the
+CML library.
+
+**Enforcement**: Pull Request Review.
+
+**Example**
+
+.. code-block:: cpp
+
+   namespace cml {
+
+   struct MyType {
+   };
+
+   void my_function(int my_param);
+
+   }
+
+**CML-MCS-CPP-2**: Header files shall direct Trick to place generated interface code in the “cml” Python module via the Trick header “PYTHON MODULE” directive
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Trick provides the option to generate Python interface code into a specific Python module rather than in
+the global “trick” scope. This prevents name collisions between CML-defined types and the types defined by Trick or
+consumers of the CML library.
+
+**Enforcement**: Static analysis.
+
+**Example**
+
+.. code-block:: cpp
+
+   /* PURPOSE: (My purpose)
+    *
+    * PYTHON_MODULE: (cml)
+    */
+
+**CML-MCS-CPP-3**: Source code shall use the .hh file extension for headers and the .cc file extension for source files
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Consistent codebases are easier to use and maintain.
+
+**Enforcement**: Static analysis.
+
+**CML-MCS-CPP-4**: Functions and types limited in scope to the implementation details of a module shall be placed in an unnamed namespace within the corresponding module source file
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Exposing internal implementation details in public headers slows down Trick interface code generation and
+may confuse users. Unnamed namespaces are the modern equivalent to static functions and types declared at the file-level.
+
+**Enforcement**: Pull Request Review.
+
+**Example**
+
+.. code-block:: cpp
+
+   // Within myfile.cc
+   namespace {
+
+   void some_local_function() {
+   }
+
+   }
+
+**CML-MCS-CPP-5**: Structs shall be used only for passive objects with all public fields that have no invariants
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Structs are widely understood by the C++ community to carry data with no invariants. Although structs may
+have protected or private fields, if such encapsulation is necessary, then classes should be used.
+
+**Enforcement**: Pull Request Review.
+
+**Examples**
+
+.. code-block:: cpp
+
+   struct JustSomeData {
+       int int_data {};
+       double double_data {1.0};
+       std::string string_data {"Some Data"};
+   };
+
+   class EncapsulationNecessary {
+   public:
+       void set_coefficient_of_friction(double coefficient_of_friction_in) {
+           if (coefficient_of_friction_in >= 0.0) {
+               coefficient_of_friction = coefficient_of_friction_in;
+           } else {
+               throw_some_error();
+           }
+       }
+
+   private:
+       double coefficient_of_friction {};
+   };
+
+**CML-MCS-CPP-6**: Source code shall compile with no warnings
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Compiler warnings signify that something may be wrong with the code and should rarely be ignored.
+
+**Enforcement**: Automated builds in GitHub Actions treat warnings as errors.
+
+**CML-MCS-CPP-7**: Source code shall pass review by linters without generating any warnings
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Linters such as ``cppcheck`` and ``clang-tidy`` are widely used in industry and provide meaningful
+feedback on potential code quality issues. These warnings should rarely be ignored.
+
+**Enforcement**: Linters are run in a GitHub Action and produce a failing result upon detecting an error.
+
+**CML-MCS-CPP-8**: Source code shall have associated unit tests which cover at least 90% of lines with meaningful tests
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Inadequately tested code is prone to introducing regressions and is not fit for use within high-fidelity
+spacecraft simulations.
+
+**Enforcement**: Manual review of code coverage artifacts generated in a GitHub Action during Pull Request Review.
+
+**CML-MCS-CPP-9**: Source code shall compile using the ISO/IEC 14882 C++17 standard
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: A reasonably recent version of the C++ language should be used by all models to leverage new language
+features and maintain interoperability with other open-source libraries.
+
+**Enforcement**: All toolchains use the minimum supported C++ standard.
+
+**CML-MCS-CPP-10**: Source code shall have associated documentation which includes, at minimum, the model’s public API, a users’ guide, assumptions and limitations, and details about prior verification and validation activities
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Code without documentation cannot be effectively maintained or used.
+
+**Enforcement**: Pull Request Review.
+
+**CML-MCS-PYTHON-1**: Source code shall not call exec(), eval(), or otherwise evaluate an arbitrary string as Python code
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Exceptions thrown within code evaluated by ``exec()`` or other related functions do not provide meaningful
+debugging information. These functions also introduce security concerns into the codebase. Use modules and functions
+instead of ``exec(open())``.
+
+**Enforcement**: Pull Request Review.
+
+**Example, wrong**
+
+.. code-block:: python
+
+   exec(open("Modified_data/utils.py").read())
+   some_function_from_utils()
+
+**Example, correct**
+
+.. code-block:: python
+
+   from Modified_data.utils import some_function_from_utils
+   some_function_from_utils()
+
+**CML-MCS-PYTHON-2**: Methods which accept keyword arguments shall document all allowable keyword arguments
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Users should not have to read implementation details to determine which keyword arguments are accepted by
+a function.
+
+**Enforcement**: Pull Request Review.
+
+**Example**
+
+.. code-block:: python
+
+   def myfunc(*args, **kwargs) -> None:
+       """Does a few things.
+
+       Keyword arguments:
+       ------------------
+       foo : An instance of Foo
+       bar : A numeric type such as an int or float
+       baz : A string-like type
+       """
+       implementation(*args, **kwargs)
+
+Best Practice Coding Standards
+------------------------------
+
+These standards cover best practice for the code within CML. These standards are not required to be met at the time of
+integration into the main CML branch but should be met as soon as possible afterwards. Like the
+`Model Coding Standards <Model Coding Standards_>`_, CML Best Practice Coding Standards are grouped by programming
+language.
+
+**CML-BP-CPP-1**: Do not define macros
+++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Macros cannot be put into a namespace and can be difficult to debug. Use function templates and inline
+variables instead.
+
+**Example, wrong**
+
+.. code-block:: cpp
+
+   #define ADD_ONE(input) (input + 1)
+
+   #define SPEED_OF_LIGHT 299792458.0
+
+**Example, correct**
+
+.. code-block:: cpp
+
+   template <typename Type>
+   constexpr Type add_one(const Type& input) {
+      return input + 1;
+   }
+
+   inline constexpr double SPEED_OF_LIGHT = 299792458.0;
+
+**CML-BP-CPP-2**: Do not invoke undefined behavior
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: The outputs of a program which invokes undefined behavior are suspect.
+
+**Note**: Most undefined behavior will be caught by static analysis tools and will be required to be addressed during
+Pull Request Review.
+
+**CML-BP-CPP-3**: Do not use global variables
++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Global variables often lead to “spaghetti code” which is difficult to maintain and understand.
+
+**CML-BP-CPP-4**: Do not use the “new” or “delete” keywords
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: The Trick Memory Manager should be used to allocate memory which must be logged or otherwise available
+for Trick-specific purposes. Otherwise, smart pointers provided by the C++ standard library should be used for
+dynamic memory management. Both of these options provide automated cleanup of the allocated memory.
+
+**Example, wrong**
+
+.. code-block:: cpp
+
+   double* my_vector = new double[num_elements];
+
+**Example, correct** using the Trick memory manager
+
+.. code-block:: cpp
+
+   auto* my_vector = static_cast<double*>(trick_TMM->declare_var("double", num_elements));
+
+**Example, correct** using smart pointers
+
+.. code-block:: cpp
+
+   auto my_vector = std:make_unique<double[]>(num_elements);
+
+**CML-BP-CPP-5**: Do not allocate significant memory in scheduled simulation jobs
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Trick scheduled jobs are often intended to be run at high frequencies for high-fidelity spacecraft
+analysis. Frequently reallocating memory during such jobs introduces performance bottlenecks and is a symptom of bad
+design. Some reallocation may be expected during certain simulation events, but most memory allocation should occur
+during simulation initialization.
+
+**CML-BP-CPP-6**: Favor composition over inheritance
+++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Frequent use of inheritance can make a codebase difficult to understand. Often, composition allows for
+easier code maintenance and testability.
+
+**CML-BP-PYTHON-1**: Use docstrings
++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Python docstrings help users use Python code correctly and are recommended by PEP 257.
+
+**Example**
+
+.. code-block:: python
+
+   def foo(bar) -> None:
+       """Foos a bar."""
+
+**CML-BP-PYTHON-2**: Use type annotations
++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Type annotations help address one of the biggest shortcomings of dynamically typed languages, where the
+types allowed as inputs or expected as outputs from functions are not always easy to deduce.
+
+**Example**
+
+.. code-block:: python
+
+   def connect(port: int, hostname: str) -> StatusCode:
+       """Attempt to connect to a port on a host."""
+       return implementation(port, hostname)
+
+**CML-BP-PYTHON-3**: Functions should always return the same number of items, preferably only one item
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Functions which return a variable number of arguments depending on the logic path taken are brittle and
+require users to understand the inner workings of the function which they are accessing.
+
+**CML-BP-PYTHON-4**: Do not use classes in code intended for use in Trick input files
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Rationale**: Classes are designed to hold state and provide access control to data, while Trick input files are
+designed to be a purely procedural interface to a simulation. Frequent overuse of classes in Trick input files has
+proven repeatedly to negatively impact code usability and maintainability. Use free functions instead.
+
+Coding Standards Waiver
+-----------------------
+
+Waivers to any coding standard may be granted on a case-by-case basis when it can be demonstrated that the following
+criteria are both met:
+1. Safeguards are in place to ensure that the exception does not create a risk to the overall project.
+2. The effort required to bring the code to a satisfactory standard would be excessive.
+
+The request for a waiver is made during Pull Request Review. The request may be in the form of a PowerPoint
+presentation, a memo, or any other format capable of conveying the following information:
+-  Violation (with code)
+-  Options for mitigation/resolution
+-  Rationale why the violation is acceptable
+-  Evaluation of risk to accepting the waiver
+
+If the waiver is granted, the request must be updated to reflect the approver, date of approval, and this information
+must be recorded with the model documentation. The complete list of waivers will be maintained separately for CML
+maintenance and metrics purposes. If the waiver is denied, the developer is directed to resolve the violation.
+
+Appendix A: Acronyms and Abbreviations
+======================================
+
+.. list-table::
+   :widths: 30 70
+
+   * - Acronym
+     - Abbreviation
+   * - CML
+     - Common Model Library
+   * - CUI
+     - Controlled Unclassified Information
+   * - EAR
+     - Export Administration Regulations
+   * - ITAR
+     - International Traffic in Arms Regulations
+   * - JEOD
+     - Johnson Space Center Engineering Orbital Dynamics
+   * - JSC
+     - Johnson Space Center
+
+Appendix B: Glossary of Terms
+=============================
+
+.. list-table::
+   :widths: 30 70
+
+   * - Term
+     - Description
+   * - Trick
+     - An open-source C++/Python driven simulation development framework. See https://github.com/nasa/trick for more
+       information.
+   * - Pull Request Review
+     - When code is ready to be reviewed and accepted into the main production branch of CML, a pull request is opened.
+       The Pull Request Review is the process by which the code is assessed for compliance with CML's code standards and
+       other NASA standards by the CML team.

--- a/models/dynamics/actions/mass_body_detach_impulsive/docs/mass_body_detach_impulsive.pdf
+++ b/models/dynamics/actions/mass_body_detach_impulsive/docs/mass_body_detach_impulsive.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de259e0e6d4bc67971f7637893c3322b7a55fe3c831867467e1edfe3d58a0fc2
-size 480589

--- a/models/dynamics/integration/accumulated_absolute_deltas/docs/accumulated_absolute_deltas.pdf
+++ b/models/dynamics/integration/accumulated_absolute_deltas/docs/accumulated_absolute_deltas.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28477b65828a1a6b9bd53c7c575e28d620b4156173ee34845b49550a3c1fd0c2
-size 242978

--- a/models/dynamics/integration/scalar_integrable_object/docs/scalar_integrable_object.pdf
+++ b/models/dynamics/integration/scalar_integrable_object/docs/scalar_integrable_object.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:379cf1d8c6fe47485946bb06825380a69e75c5b590230cb5c1005bc69063218b
-size 107260

--- a/models/dynamics/integration/vector3_integrable_object/docs/integrable_object.pdf
+++ b/models/dynamics/integration/vector3_integrable_object/docs/integrable_object.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3878de8f6258040ae7c857f586e7287c60f888348c0ef2c3508265f83c9521c7
-size 297504

--- a/models/dynamics/mass/dynamic_mass/docs/dynamic_mass.pdf
+++ b/models/dynamics/mass/dynamic_mass/docs/dynamic_mass.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e613927a407c6bcff9a5ab0db26bf1c7c07422f776e7534f0d680eda1b3565fb
-size 316312

--- a/models/dynamics/mass/mass_body_dispersed_init/docs/mass_body_dispersed_init.pdf
+++ b/models/dynamics/mass/mass_body_dispersed_init/docs/mass_body_dispersed_init.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b2389aa34898159607f82ce79251687af53fcd0638528a84184bee6f5897908
-size 340083

--- a/models/dynamics/mass/mass_body_distribute_comp_to_core/docs/mass_body_distribute_comp_to_core.pdf
+++ b/models/dynamics/mass/mass_body_distribute_comp_to_core/docs/mass_body_distribute_comp_to_core.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7354767ffd5cadd2d3a8a8c8fc521386e2d54aeb511d64d659fc2ad900b676a
-size 429985

--- a/models/dynamics/mass_derivative_dynamics/docs/mass_derivative_dynamics.pdf
+++ b/models/dynamics/mass_derivative_dynamics/docs/mass_derivative_dynamics.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac1c8549ee4520f6cf74e157817da524b7931df66888ae193619ca30210def2f
-size 2514038

--- a/models/dynamics/state_descriptors/atmos_rel_state/docs/atmos_rel_state.pdf
+++ b/models/dynamics/state_descriptors/atmos_rel_state/docs/atmos_rel_state.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c70b0716f82b776379992e3c84febb55493857104944b635fc99b4e7c956ffe1
-size 409635

--- a/models/dynamics/state_descriptors/earth_moon_rotating_frame/docs/earth_moon_rotating_frame.pdf
+++ b/models/dynamics/state_descriptors/earth_moon_rotating_frame/docs/earth_moon_rotating_frame.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74e6c3c7ba95a35bb072579a431d329214588d2552674b1558b8b4559507ccd9
-size 785713

--- a/models/dynamics/state_descriptors/earth_moon_rotating_frame/docs/earth_moon_rotating_frame_presentation.pdf
+++ b/models/dynamics/state_descriptors/earth_moon_rotating_frame/docs/earth_moon_rotating_frame_presentation.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d1de289234e88c459f2c06841199921af6d38a539a86ee9f1763248501e56d3
-size 325888

--- a/models/dynamics/state_descriptors/extended_planetary_derived_state/docs/extended_planetary_derived_state.pdf
+++ b/models/dynamics/state_descriptors/extended_planetary_derived_state/docs/extended_planetary_derived_state.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b80717046b839e0a1314be885df0bc605c94135031370943d3cfa22f68de9406
-size 2012192

--- a/models/dynamics/state_descriptors/extended_planetary_derived_state/docs/extended_planetary_derived_state_presentation_VV.pdf
+++ b/models/dynamics/state_descriptors/extended_planetary_derived_state/docs/extended_planetary_derived_state_presentation_VV.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fbd5475412cc25395e520c88bf79c6b8c70ddfc9fb17d008f5ad4f6c8825d7b
-size 341379

--- a/models/dynamics/state_descriptors/orb_elem_subset/docs/orb_elem_subset.pdf
+++ b/models/dynamics/state_descriptors/orb_elem_subset/docs/orb_elem_subset.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:760a20d778be635777e680a13918391bce51d487ef565f922ed45403010a2b86
-size 112389

--- a/models/dynamics/state_descriptors/pointing_ref_frame/docs/pointing_ref_frame.pdf
+++ b/models/dynamics/state_descriptors/pointing_ref_frame/docs/pointing_ref_frame.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97ca0965c8a9c8f83c01dab986cd55f55afbe2b6fc799167b92fde9deba7815b
-size 682757

--- a/models/dynamics/state_descriptors/pointing_ref_frame/docs/pointing_ref_frame_presentation.pdf
+++ b/models/dynamics/state_descriptors/pointing_ref_frame/docs/pointing_ref_frame_presentation.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fecc2421ca8892bfb8ff7e8be888a083db0986fb37888bd3dce576d395dbc71
-size 417713

--- a/models/dynamics/state_descriptors/range/docs/range.pdf
+++ b/models/dynamics/state_descriptors/range/docs/range.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39ab37c294967993186516fa0140994566fc642d8318703394bbbe9758ca6bb3
-size 855726

--- a/models/dynamics/state_descriptors/separation_state/docs/separation_state.pdf
+++ b/models/dynamics/state_descriptors/separation_state/docs/separation_state.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53dc07b02f63ae56fedf7944c3b80d4aa0e1afdebdfc0326063e3b32db587349
-size 173265

--- a/models/dynamics/state_descriptors/simple_planet_rel_state/docs/simple_planet_rel_state.pdf
+++ b/models/dynamics/state_descriptors/simple_planet_rel_state/docs/simple_planet_rel_state.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a4015e51360d53b8ed113d9a8e7db5ec3cf787510a7ef145104f83c7009c04b
-size 114554

--- a/models/dynamics/state_initialize/correlated_state_dispersion/docs/correlated_state_dispersion.pdf
+++ b/models/dynamics/state_initialize/correlated_state_dispersion/docs/correlated_state_dispersion.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa1106b893fd4a7b9f6e3d18e9dca71c8a438d522673a8069edaac8f257637b6
-size 482925

--- a/models/dynamics/state_initialize/state_initialize/docs/state_initialize.pdf
+++ b/models/dynamics/state_initialize/state_initialize/docs/state_initialize.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc35e6534f2baf560ef355f9855460a21d7fe12c93f1454024d9a0620a7603c9
-size 407625

--- a/models/dynamics/state_initialize/target_relative_parameters/docs/target_relative_parameters.pdf
+++ b/models/dynamics/state_initialize/target_relative_parameters/docs/target_relative_parameters.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b354061b5824cc73de51096bdc13797a6fe0f2fedc963f40fd72a86e7e330bc8
-size 187007

--- a/models/dynamics/state_overrides/contact/docs/contact_state_override.pdf
+++ b/models/dynamics/state_overrides/contact/docs/contact_state_override.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:479482e68102a9597e62dfa514cba1450587f9b5e781663a14fc12d06ea332c7
-size 861725

--- a/models/dynamics/state_overrides/contact/docs/contact_state_override_VV.pdf
+++ b/models/dynamics/state_overrides/contact/docs/contact_state_override_VV.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f992a23d2c3645aaac0b001170033931ce550fa38326e10ce454b9ee46c096f
-size 327340

--- a/models/dynamics/state_overrides/twist_sway/docs/Twist_sway.pdf
+++ b/models/dynamics/state_overrides/twist_sway/docs/Twist_sway.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0842a9a1f60a00783a13746aed04a7fa942cfdae06725f6eb50caaa2ef58ae5
-size 3991257

--- a/models/dynamics/state_predictors/apsides_predictor/docs/apsides_predictor.pdf
+++ b/models/dynamics/state_predictors/apsides_predictor/docs/apsides_predictor.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c61cae664452d5f72446a5a845691663a8f4f6ac722e98255c1c99c80f2bb2a
-size 301669

--- a/models/dynamics/state_predictors/impact_point/docs/impact_point.pdf
+++ b/models/dynamics/state_predictors/impact_point/docs/impact_point.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32463bf660e78cbbb0131b801dd7eeb111ef768c8e46b622dc5f25660e374a5a
-size 145282

--- a/models/environment/atmos/atmos_exec/docs/atmos_exec.pdf
+++ b/models/environment/atmos/atmos_exec/docs/atmos_exec.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cc373612496264b40a656124c0d829ecc763df02e8e091118098f826c1785d1
-size 138979

--- a/models/environment/atmos/atmos_exec/docs/atmos_exec_V&V.pdf
+++ b/models/environment/atmos/atmos_exec/docs/atmos_exec_V&V.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72b977adbe24ab119d239d473685a278ef79a1dbeb90455daddd5bec101bb0f1
-size 1011837

--- a/models/environment/atmos/atmos_exec/docs/atmos_exec_delta_VV.pdf
+++ b/models/environment/atmos/atmos_exec/docs/atmos_exec_delta_VV.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:966d25ad6f9233f6da9574bde38f9622a4e4066eb15fd9ba7aab0ece08977290
-size 435302

--- a/models/environment/atmos/atmosphere_models/DRWP_atmos/docs/DRWP_VV.pdf
+++ b/models/environment/atmos/atmosphere_models/DRWP_atmos/docs/DRWP_VV.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd101799f84bf3bba1ecf387e7b12f2aa1f511cfbab3e05792eaed6d91993687
-size 301718

--- a/models/environment/atmos/first_order_hold/docs/first_order_hold.pdf
+++ b/models/environment/atmos/first_order_hold/docs/first_order_hold.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41b9e29cbc830a27ab8b245a917f170e7509c5dba9eec5527f3f296e5984877b
-size 116478

--- a/models/environment/atmos/gust/docs/gust.pdf
+++ b/models/environment/atmos/gust/docs/gust.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b759f7b0b8b5199d26c06ff776267d582cb41441e6a7011bc0a76f444ba14d21
-size 489181

--- a/models/environment/atmos/gust/docs/gust_VV.pdf
+++ b/models/environment/atmos/gust/docs/gust_VV.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94522d911ad294a73ac684c019026bc35a060b51956af3190cea6ec6703b895a
-size 302021

--- a/models/environment/atmos/lagged_atmosphere/docs/lagged_atmosphere.pdf
+++ b/models/environment/atmos/lagged_atmosphere/docs/lagged_atmosphere.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8afeba525230d036053f178f042097d7de6df3255cebf15cb99c14b1d8f1b35c
-size 228934

--- a/models/environment/atmos/lagged_atmosphere/docs/lagged_atmosphere_VV.pdf
+++ b/models/environment/atmos/lagged_atmosphere/docs/lagged_atmosphere_VV.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3f3488aa9f374d1c7acd1f5fe8b6527c38e71d7e99add144a4f5f0f78c866f2
-size 359959

--- a/models/environment/eclipse_calculator/docs/eclipse_calculator.pdf
+++ b/models/environment/eclipse_calculator/docs/eclipse_calculator.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f74507d5bad89ce9d0bacdebeded097b1d457de43bc8fe8cca0cb4db0946e0d
-size 108130

--- a/models/environment/ephemerides/planet_planet_state/docs/planet_planet_state.pdf
+++ b/models/environment/ephemerides/planet_planet_state/docs/planet_planet_state.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bef60610dcb24481adbbd130089da0b1f9268489a7409e5c113a54df6e24fe03
-size 275358

--- a/models/environment/gravity/fast_gravity/docs/fast_gravity.pdf
+++ b/models/environment/gravity/fast_gravity/docs/fast_gravity.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bdc7d584374348cd47b46603f98b7bcf41cda7d8e4e7fc59bf6e28f90bd8ac8
-size 360734

--- a/models/environment/gravity/gravity_fidelity_manager/docs/gravity_fidelity_manager.pdf
+++ b/models/environment/gravity/gravity_fidelity_manager/docs/gravity_fidelity_manager.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:920ca2cb1d08764f6f64d55bce7fcd8fc2a48b99ed680de8fb52632344b9d677
-size 82915

--- a/models/fhw/effectors/piston_thruster/docs/piston_thruster.pdf
+++ b/models/fhw/effectors/piston_thruster/docs/piston_thruster.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c548e3fdb9f0b8c843d80438202cc7c84ccbbccaa9bd7c8e749b8bb517eec19
-size 138050

--- a/models/fhw/effectors/springs/docs/mass_body_detach_with_springs.pdf
+++ b/models/fhw/effectors/springs/docs/mass_body_detach_with_springs.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8510726b1b06e5de25419c7027c2679d31750b4c795d079392e813f5b2cfa411
-size 102466

--- a/models/fhw/effectors/springs/docs/springs.pdf
+++ b/models/fhw/effectors/springs/docs/springs.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:658f1331ecb0f58bc2c9bbedbb847ca030e06c3ad287526124f93a3660276e84
-size 162220

--- a/models/fhw/effectors/vent/docs/vent.pdf
+++ b/models/fhw/effectors/vent/docs/vent.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93a15f8d90787c0a070e8f65b7c355aa79b01cd52a370a49b283253b92242821
-size 355860

--- a/models/fhw/effectors/vent/docs/vent_presentation.pdf
+++ b/models/fhw/effectors/vent/docs/vent_presentation.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:096fe7d084ff5ad79b07966435cf21399d4f30f5d3a8b76d2d5e06f7ffd935d1
-size 317022

--- a/models/interactions/aero/docs/aero.pdf
+++ b/models/interactions/aero/docs/aero.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f8912cc9a92edba7277f5249dcdfd41fc6845ac58b0239dbeff15856205806d
-size 281422

--- a/models/interactions/subsonic_wake/docs/subsonic_wake.pdf
+++ b/models/interactions/subsonic_wake/docs/subsonic_wake.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e11263913f1eb25377e7d7b8fbf61b349655c4dcb52e67005c88925411204aba
-size 232403

--- a/models/tools/unit_test/models/docs/unit_test.pdf
+++ b/models/tools/unit_test/models/docs/unit_test.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53cd50f5931332bd11b5ef08b310044559f3b20a3c605b261d8af3ba2730e7d2
-size 114431

--- a/models/utilities/bin_counter/docs/bin_counter.pdf
+++ b/models/utilities/bin_counter/docs/bin_counter.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc41f526bc7742f0e262564e12c60150e3ef39576020e8a4712a1eda1e47fabc
-size 1395889

--- a/models/utilities/bin_counter/docs/bin_counter_presentation.pdf
+++ b/models/utilities/bin_counter/docs/bin_counter_presentation.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fb674b945008d2f6898eac50a657337a21d741b2e3ba0fb6189acb521a2a2ef
-size 280577

--- a/models/utilities/buffers/docs/buffers.pdf
+++ b/models/utilities/buffers/docs/buffers.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93c721ad3eb8e56f27139a003f368f0cc59acb64edbe03dec7bdc8c46caafcd4
-size 176335

--- a/models/utilities/cml_message/docs/cml_message_VV.pdf
+++ b/models/utilities/cml_message/docs/cml_message_VV.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea4b8eb04b63bfec73acfe1dc45e8f6cbc05bbf7dd6cdb94c62d84f59ba5dc9b
-size 286809

--- a/models/utilities/color_string/docs/color_string.pdf
+++ b/models/utilities/color_string/docs/color_string.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:979e66d77efaa528df21e4d2dc61f88a80fc35319231ed40caa149c938c1791b
-size 368279

--- a/models/utilities/color_string/docs/color_string_presentation.pdf
+++ b/models/utilities/color_string/docs/color_string_presentation.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3249099e945f9299b48c883b02e7e9059e953cd6beeb4d4c1a46d4e658993ae2
-size 299616

--- a/models/utilities/constraint_check/docs/constraint_check.pdf
+++ b/models/utilities/constraint_check/docs/constraint_check.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dca50e1bb7b1686a9dc8c1c972fccf3e40c994d715c8c8a49f057cbb8e39112
-size 192375

--- a/models/utilities/double_to_words/docs/double_to_words.pdf
+++ b/models/utilities/double_to_words/docs/double_to_words.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b98e85173be70f2c6c1fbff81bae20ab444aad7927eb7a103a6cb92e5de0f85d
-size 108374

--- a/models/utilities/double_to_words/docs/double_to_words_C.pdf
+++ b/models/utilities/double_to_words/docs/double_to_words_C.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:54027f1c3106d935b7ec332be677f89c5abbcb1789ce0ce88ad9a29314b115e2
-size 87220

--- a/models/utilities/enhanced_logging/docs/enhanced_logging.pdf
+++ b/models/utilities/enhanced_logging/docs/enhanced_logging.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea58ca869f14e420c99eb712afe49649dab6d788c12dee61c338c1b9afe37cb9
-size 505168

--- a/models/utilities/math_utils/docs/math_utils_presentation.pdf
+++ b/models/utilities/math_utils/docs/math_utils_presentation.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c8cd42cddd8353eb06dd0248b3c1ae5670bb4a90ebd3b49fb81cfd6e1c4dd29
-size 346345

--- a/models/utilities/subscriptions/docs/subscriptions.pdf
+++ b/models/utilities/subscriptions/docs/subscriptions.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e638e050df7467737cfe05a510f78c88f024e694a069e19ad0437c3f3b2af4ef
-size 297099

--- a/models/utilities/subscriptions/docs/subscriptions_presentation.pdf
+++ b/models/utilities/subscriptions/docs/subscriptions_presentation.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65c0b79d6a691874d591e7989e7b6c57a5750c9f5b825b5999662159ce2d8ad5
-size 318854

--- a/models/utilities/trick_logging/docs/trick_logging.pdf
+++ b/models/utilities/trick_logging/docs/trick_logging.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8f2a64846e68e97d489d6e35eac3d99ddcd8b2de6752c7fc0a88c6b98992510
-size 99499

--- a/models/vehicle_management/commandable_action/docs/commandable_action.pdf
+++ b/models/vehicle_management/commandable_action/docs/commandable_action.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c152eeaa9df578bf89a01a9a6cd2b7b404692469b44b06a76d35e25b30075a9e
-size 477127

--- a/models/vehicle_management/compound_events/docs/compound_events.pdf
+++ b/models/vehicle_management/compound_events/docs/compound_events.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80f585bdad060b3991ba5314c59d334f986dd73b40e5e142c933ea564604364d
-size 267093

--- a/models/vehicle_management/dummy_vehicle_launcher/docs/dummy_vehicle_launcher.pdf
+++ b/models/vehicle_management/dummy_vehicle_launcher/docs/dummy_vehicle_launcher.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbff3079756d54102ba269904104bfb95cc57191b8d97e550964be5fd87a5e29
-size 103212

--- a/models/vehicle_management/events_manager/docs/events_manager.pdf
+++ b/models/vehicle_management/events_manager/docs/events_manager.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:996bc0012676036616246179fd9b39eca12f3c80d69e124453b7b701f0c51185
-size 1216257


### PR DESCRIPTION
Remove a bunch of PDF files which just store the same data as the source .docx, .ppt, etc. format which they were generated from. We're still limited to 10GB of LFS traffic a month so we should try to use LFS as sparingly as possible.

Closes #55