### PR TITLE
Create initial clang-tidy action

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,35 @@
 ---
+# Ignored warnings:
+#
+# bugprone:
+#     To be added in a future pull request
+#
+# clang-analyzer:
+#     clang-analyzer-optin.performance.Padding:
+#         Can end up being detrimental by suggesting that certain fields which
+#         were grouped together for logical coherence be split apart. It's more
+#         important that the data is easy to read than it is to save a few bytes
+#         of padding.
+#
+# misc:
+#     To be added in a future pull request
+#
+# modernize:
+#     To be added in a future pull request
+#
+# performance:
+#     To be added in a future pull request
+#
+# portability:
+#     To be added in a future pull request
+#
+# readability:
+#     To be added in a future pull request
+Checks: >
+    clang-*,
+    -clang-analyzer-optin.performance.Padding
+
 WarningsAsErrors: '*'
+
 HeaderFilterRegex: '(^|/)(models|utility)/.*'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+WarningsAsErrors: '*'
+HeaderFilterRegex: '(^|/)(models|utility)/.*'
+...

--- a/.github/actions/build-jeod/action.yml
+++ b/.github/actions/build-jeod/action.yml
@@ -10,11 +10,16 @@ inputs:
     required: true
   jeod-version:
     description: JEOD git branch/tag to build
-    required: true
+    required: false
+    default: jeod_v5.4.1
   venv-path:
     description: Path to the Python virtual environment
     required: false
     default: .venv
+  clone-only:
+    description: If true, only clone JEOD and skip building it
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -24,9 +29,16 @@ runs:
       env:
         TRICK_HOME: ${{ inputs.trick-home }}
       run: |
-        source ${{ inputs.venv-path }}/bin/activate
         git clone https://github.com/nasa/jeod.git \
+          --depth 1 \
           --branch ${{ inputs.jeod-version }} ${{ inputs.jeod-home }}
+
+        if [ "${{ inputs.clone-only }}" = "true" ]; then
+          echo "clone-only is true; skipping JEOD build and trickification."
+          exit 0
+        fi
+
+        source ${{ inputs.venv-path }}/bin/activate
         cd ${{ inputs.jeod-home }}
         make -f bin/jeod/makefile -j$(nproc) TRICK_BUILD=1
         cd ${{ inputs.jeod-home }}/trickified

--- a/.github/actions/build-trick/action.yml
+++ b/.github/actions/build-trick/action.yml
@@ -7,11 +7,16 @@ inputs:
     required: true
   trick-version:
     description: Trick git branch/tag to build
-    required: true
+    required: false
+    default: 25.1.0
   venv-path:
     description: Path to the Python virtual environment
     required: false
     default: .venv
+  clone-only:
+    description: If true, only clone Trick and skip building it
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -19,9 +24,16 @@ runs:
     - name: Build Trick
       shell: bash
       run: |
-        source ${{ inputs.venv-path }}/bin/activate
         git clone https://github.com/nasa/trick.git \
+          --depth 1 \
           --branch ${{ inputs.trick-version }} ${{ inputs.trick-home }}
+
+        if [ "${{ inputs.clone-only }}" = "true" ]; then
+          echo "clone-only is true; skipping Trick build."
+          exit 0
+        fi
+
+        source ${{ inputs.venv-path }}/bin/activate
         cd ${{ inputs.trick-home }}
         ./configure
         make -j$(nproc)

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -74,3 +74,70 @@ jobs:
           path: "*.log"
           if-no-files-found: warn
           retention-days: 2
+
+
+  clang-tidy:
+    runs-on: ubuntu-latest
+    container:
+      image: rockylinux:8
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Install system dependencies
+        run: |
+          dnf install -y epel-release
+          dnf config-manager --enable powertools
+          dnf update -y
+          dnf install -y git make cmake gcc gcc-c++ libxml2-devel openmotif-devel \
+            perl perl-Digest-MD5 udunits2-devel zlib-devel libX11-devel libXt-devel \
+            python3-devel clang-tools-extra
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure environment
+        run: |
+          echo "CML_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          echo "TRICK_HOME=$GITHUB_WORKSPACE/externals/trick" >> "$GITHUB_ENV"
+          echo "JEOD_HOME=$GITHUB_WORKSPACE/externals/jeod" >> "$GITHUB_ENV"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          echo "SSL_CERT_FILE=/etc/pki/tls/cert.pem" >> "$GITHUB_ENV"
+
+      - name: Clone Trick
+        uses: ./.github/actions/build-trick
+        with:
+          trick-home: ${{ env.TRICK_HOME }}
+          clone-only: "true"
+
+      - name: Clone JEOD
+        uses: ./.github/actions/build-jeod
+        with:
+          trick-home: ${{ env.TRICK_HOME }}
+          jeod-home: ${{ env.JEOD_HOME }}
+          clone-only: "true"
+
+      - name: Generate compile commands
+        run: cmake --preset user-debug --fresh
+
+      - name: Run clang-tidy
+        run: |
+          set -o pipefail
+          run-clang-tidy \
+            -p build/debug \
+            -j $(nproc) \
+            -quiet \
+            -extra-arg=-Wno-unknown-warning-option \
+            -extra-arg=-w \
+            2>&1 | tee clang-tidy.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-failure-logs
+          path: clang-tidy.log
+          if-no-files-found: warn
+          retention-days: 2

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -131,7 +131,7 @@ jobs:
             -quiet \
             -extra-arg=-Wno-unknown-warning-option \
             -extra-arg=-w \
-            2>&1 | tee clang-tidy.log
+            | tee clang-tidy.log
 
       - name: Upload logs on failure
         if: failure()

--- a/models/environment/atmos/atmosphere_models/std_atmos_1976/include/std_atmos_1976.hh
+++ b/models/environment/atmos/atmosphere_models/std_atmos_1976/include/std_atmos_1976.hh
@@ -47,7 +47,7 @@ public:
    double dynamic_viscosity ;             /* (N*s/m2)      Dynamic viscosity         */
    double molecular_weight ;              /* --            Molecular weight          */
    double mean_free_path;                 /* (m)           Mean free path            */
-   int    layer_number ;                  /* --            Layer number               */
+   size_t layer_number ;                  /* --            Layer number               */
   
    /** constructor, and initialize the 
    *   state as that at mean sea level.

--- a/models/environment/atmos/atmosphere_models/std_atmos_1976/src/std_atmos_1976.cc
+++ b/models/environment/atmos/atmosphere_models/std_atmos_1976/src/std_atmos_1976.cc
@@ -68,8 +68,8 @@ void STD1976::initialize()
 void STD1976::update(const double &altitude_in  //the given geometric height
                     )
 {
-  static const size_t rmwx_num = sizeof(RMWX_table)/sizeof(RMWX_table[0]);
-  static const size_t ext_alt_num = sizeof(ext_alt_table)/sizeof(ext_alt_table[0]);
+  static const size_t rmwx_num = std::size(RMWX_table);
+  static const size_t ext_alt_num = std::size(ext_alt_table);
   static const size_t alt_num = get_alt_tbl_len();
 
   altitude = altitude_in;
@@ -110,10 +110,10 @@ void STD1976::update(const double &altitude_in  //the given geometric height
   if (altitude > alt_table[0]) { //form 0 km to 1000 km
     const double *itr = std::upper_bound(alt_table, alt_table+alt_num, H);
     if (itr == alt_table+alt_num) {
-      layer_number = static_cast<int>(alt_num-1);
+      layer_number = alt_num-1;
     }
     else {
-      layer_number = static_cast<int>(std::distance(alt_table, itr)-1);
+      layer_number = static_cast<size_t>(std::distance(alt_table, itr)-1);
     }
   }
 

--- a/models/environment/atmos/atmosphere_models/std_atmos_1976/src/std_atmos_1976_dd.cc
+++ b/models/environment/atmos/atmosphere_models/std_atmos_1976/src/std_atmos_1976_dd.cc
@@ -19,6 +19,7 @@ PROGRAMMERS:
 ********************************************************************************/
 
 #include <cmath>
+#include <iterator> // std::size for C-style arrays
 
 #include "trick/trick_math.h"  //for M_PI
 #include "cml/models/utilities/cml_message/include/cml_message.hh"
@@ -97,14 +98,14 @@ STD1976::PY_table[87]      = {3.7338E-1, 3.1259E-1, 2.6173E-1, 2.1919E-1, 1.8359
 
 size_t STD1976::get_alt_tbl_len()
 {
-  const size_t alt_tbl_len = sizeof(alt_table)/sizeof(double);
+  static const size_t alt_tbl_len = std::size(alt_table);
   for (size_t i=1; i<alt_tbl_len; ++i) {
     if (alt_table[i] <= alt_table[i-1]) {
       CMLMessage::fail(__FILE__, __LINE__, "Data out of order.\n", "Data in table alt_table should be in increasing order.");
     }
   }
 
-  const size_t ext_alt_tbl_len = sizeof(ext_alt_table)/sizeof(double);
+  static const size_t ext_alt_tbl_len = std::size(ext_alt_table);
   for (size_t i=1; i<ext_alt_tbl_len; ++i) {
     if (ext_alt_table[i] <= ext_alt_table[i-1]) {
       CMLMessage::fail(__FILE__, __LINE__, "Data out of order.\n", "Data in table ext_alt_table should be in increasing order.");

--- a/models/utilities/fault_management/src/fault_manager.cc
+++ b/models/utilities/fault_management/src/fault_manager.cc
@@ -1440,7 +1440,9 @@ TriggerBase* FaultManager::parse_trigger(
       // make_trigger.
       Trigger<std::string>* string_trigger =
         new Trigger<std::string>(*static_cast<std::string*>(Symbol->address));
-      string_trigger->set_value(value);
+      if (value != nullptr) {
+        string_trigger->set_value(value);
+      }
       new_trigger = string_trigger;
       break;
     }

--- a/models/utilities/table_interp_cpp/src/quaternion_spherical_interpolator.cc
+++ b/models/utilities/table_interp_cpp/src/quaternion_spherical_interpolator.cc
@@ -76,7 +76,7 @@ QuaternionSphericalInterpolator::update()
         CMLMessage::error( __FILE__, __LINE__,
             "Error in Spherical interpolation. Quat_1 is invalid.\n"
             "Zeroing Quat_1.\nReturning normalized Quat_0.");
-        quat_out.copy_from(quat_0);
+        quat_out = quat_0;
         return;
       }
     }
@@ -86,7 +86,7 @@ QuaternionSphericalInterpolator::update()
           "Error in Spherical interpolation. Quat_0 is invalid.\n"
           "Zeroing Quat_0.\nReturning normalized Quat_1.");
       quat_1.normalize();
-      quat_out.copy_from(quat_1);
+      quat_out = quat_1;
       return;
     }
 


### PR DESCRIPTION
Set up the basic `clang-tidy` checks and added them to the CI pipeline. There's several sibling issues for adding the additional checks like `bugprone-*`, `modernize-*`, etc. that will happen in separate pull requests.

Changes to address `clang-tidy` warnings:
- Converted the `std_atmos_1976` model's `layer_number` variable from a signed to an unsigned integer. `clang-tidy` identified a path where that value could theoretically be negative and we'd therefore access data outside of an array bounds.
- General updates in `std_atmos_1976`: use `std::size(thing)` rather than `sizeof(thing) / sizeof(thing[0])`.
- Added a guard that ensures `value` is not `nullptr` for the case of a `Trigger<std::string>::set_value`, since that would attempt to construct a string from a null `char*`.  Making this a no-op mimics what's being done for non-`std::string` trigger types in `FaultManager::make_trigger`, where we only set the value if the input value is not null, so I believe this is correct.
- Updated some quaternion copies from using `lhs.copy_from(other)` to `lhs = other`. That `copy_from` function expects a `double[4]` as input, which JEOD quaternions are technically convertible to, but that conversion to an array passes the address of the quaternion scalar element and relies on the fact that the vector portion is adjacent in memory. `clang-tidy` flags that as an out-of-bounds read of the scalar element.

Closes #49