### PR TITLE
Support Rocky Linux 9

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,6 +1,6 @@
 export CML_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export CTEST_PARALLEL_LEVEL=10
-export ASAN_OPTIONS="suppressions=${CML_HOME}/utility/sanitizers/asan.supp"
+export ASAN_OPTIONS="suppressions=${CML_HOME}/utility/sanitizers/asan.supp:fast_unwind_on_malloc=0"
 export LSAN_OPTIONS="suppressions=${CML_HOME}/utility/sanitizers/lsan.supp"
 
 venv="${CML_HOME}/.venv/bin/activate"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,17 +25,17 @@ jobs:
     steps:
       - name: Install system dependencies
         run: |
-          dnf config-manager --set-enabled crb
-          dnf config-manager --enable powertools
           dnf install -y epel-release
           dnf update -y
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --enable crb
           dnf install -y \
             bison clang clang-devel cmake diffutils flex gcc \
             gcc-c++ git java-17-openjdk-devel \
             libxml2-devel llvm-devel llvm-static maven ncurses-devel \
             openmotif openmotif-devel perl perl-Digest-MD5 python3-devel \
-            swig udunits2 udunits2-devel which zlib-devel
-          dnf install -y gtest-devel gmock-devel libasan liblsan libubsan
+            swig udunits2 udunits2-devel which zlib-devel \
+            gtest-devel gmock-devel libasan liblsan libubsan
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,76 @@
+# This workflow tests the CML build on other supported operating systems.
+name: Builds
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rocky-linux-9:
+    runs-on: ubuntu-latest
+    container:
+      image: rockylinux:9
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Install system dependencies
+        run: |
+          dnf config-manager --set-enabled crb
+          dnf config-manager --enable powertools
+          dnf install -y epel-release
+          dnf update -y
+          dnf install -y \
+            bison clang clang-devel cmake diffutils flex gcc \
+            gcc-c++ git java-17-openjdk-devel \
+            libxml2-devel llvm-devel llvm-static maven ncurses-devel \
+            openmotif openmotif-devel perl perl-Digest-MD5 python3-devel \
+            swig udunits2 udunits2-devel which zlib-devel
+          dnf install -y gtest-devel gmock-devel libasan liblsan libubsan
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure environment
+        run: |
+          echo "MAKEFLAGS=-j$(nproc)" >> "$GITHUB_ENV"
+          echo "CML_HOME=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          echo "TRICK_HOME=$GITHUB_WORKSPACE/externals/trick" >> "$GITHUB_ENV"
+          echo "JEOD_HOME=$GITHUB_WORKSPACE/externals/jeod" >> "$GITHUB_ENV"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          echo "SSL_CERT_FILE=/etc/pki/tls/cert.pem" >> "$GITHUB_ENV"
+
+      - name: Set up Python virtual environment
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip3 install --upgrade pip
+          pip3 install .
+
+      - name: Build Trick
+        uses: ./.github/actions/build-trick
+        with:
+          trick-home: ${{ env.TRICK_HOME }}
+
+      - name: Build JEOD
+        uses: ./.github/actions/build-jeod
+        with:
+          trick-home: ${{ env.TRICK_HOME }}
+          jeod-home: ${{ env.JEOD_HOME }}
+
+      - name: Trickify CML
+        run: make -C trickified
+
+      - name: Build CML
+        run: |
+          cmake --preset dev
+          cmake --build --preset dev -t cml_shared -t cml_static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This is the main workflow for testing CML. It sets up dependencies, builds
 # CML, runs unit tests, builds and runs verification sims, and checks to make
 # sure that the committed verification data is reproducible.
-name: Build and Test CML
+name: Continuous Integration
 
 on:
   push:
@@ -15,8 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build and Test
+  test:
     runs-on: ubuntu-latest
     container:
       image: rockylinux:8

--- a/cmake/SetCMLCompileWarnings.cmake
+++ b/cmake/SetCMLCompileWarnings.cmake
@@ -19,6 +19,10 @@ function(set_cml_compile_warnings TARGET)
         -Wextra
         -Wpedantic
 
+        # TODO Nino Tarantino 8/11/2026: Re-enable as part of
+        # https://github.com/nasa/cml/issues/27
+        -Wno-overloaded-virtual
+
         # Stricter warnings.
         -Walloca
         -Wcast-align

--- a/models/dynamics/mass/dynamic_mass/verif/SIM_two_tank_unit/RUN_22_initialization_sequence_error/input.py
+++ b/models/dynamics/mass/dynamic_mass/verif/SIM_two_tank_unit/RUN_22_initialization_sequence_error/input.py
@@ -2,7 +2,7 @@
 exec(open("RUN_01_parallel_tanks/input.py").read())
 
 # give the dummy_body a name
-mass_test.dummy_body.name = "dummy_body"
+mass_test.dummy_body.set_name("dummy_body")
 
 # trigger "Initialization sequence error" in dynamic_body_mass.cc, line 79
 mass_test.dummy_body.initialize_dyn_mass()

--- a/models/dynamics/mass/dynamic_mass/verif/SIM_two_tank_unit/RUN_23_update_mass_error/input.py
+++ b/models/dynamics/mass/dynamic_mass/verif/SIM_two_tank_unit/RUN_23_update_mass_error/input.py
@@ -3,7 +3,7 @@
 exec(open("RUN_01_parallel_tanks/input.py").read())
 
 # give the dummy_body a name
-mass_test.dummy_body.name = "dummy_body"
+mass_test.dummy_body.set_name("dummy_body")
 
 # trigger "update mass error" in dynamic_body_mass.cc, line 376
 mass_test.dummy_body.initiate_dry_mass_config();

--- a/models/dynamics/mass/mass_body_distribute_comp_to_core/verif/SIM_verif/Modified_data/env_setup.py
+++ b/models/dynamics/mass/mass_body_distribute_comp_to_core/verif/SIM_verif/Modified_data/env_setup.py
@@ -3,7 +3,7 @@ dynamics.dyn_manager_init.mode = trick.DynManagerInit.EphemerisMode_EmptySpace
 dynamics.dyn_manager_init.central_point_name = "Space"
 
 for ii in range(3):
-  so.body[ii].name = "body_"+str(ii)
+  so.body[ii].set_name("body_"+str(ii))
 
   so.mass_init[ii].set_subject_body( so.body[ii] )
   so.mass_init[ii].properties.mass = 3.0-ii

--- a/models/dynamics/state_initialize/state_initialize/src/state_initialize.cc
+++ b/models/dynamics/state_initialize/state_initialize/src/state_initialize.cc
@@ -1586,7 +1586,8 @@ Note -- see documentatation for CorrelatedStateDispersion for demonstration of
 void
 StateInitialize::generate_random(int seed)
 {
-  std::default_random_engine generator(seed);
+  std::default_random_engine generator;
+  generator.seed(static_cast<typename decltype(generator)::result_type>(seed));
   std::normal_distribution<double> rand_norm(0.0, 1.0);
 
   for (unsigned int ii = 0; ii < 3; ii++) {

--- a/models/environment/atmos/lagged_atmosphere/include/lagged_atmos_payload_data.hh
+++ b/models/environment/atmos/lagged_atmosphere/include/lagged_atmos_payload_data.hh
@@ -45,14 +45,8 @@ class LaggedAtmosPayloadData {
   }
 
   // copy-constructor
-  LaggedAtmosPayloadData( const LaggedAtmosPayloadData& orig)
-    :
-    altitude(orig.altitude),
-    density(orig.density),
-    speed_of_sound(orig.speed_of_sound)
-  {
-    jeod::Vector3::copy(orig.planetodetic_wind_velocity,
-                        planetodetic_wind_velocity);
-  }
+  LaggedAtmosPayloadData(const LaggedAtmosPayloadData& orig) = default;
+  // copy assignment operator
+  LaggedAtmosPayloadData& operator=(const LaggedAtmosPayloadData& orig) = default;
 };
 #endif

--- a/models/interactions/aero/src/aero_executive_table.cc
+++ b/models/interactions/aero/src/aero_executive_table.cc
@@ -564,7 +564,7 @@ AeroExecutiveTable::aero_forces_moments()
       //   Added a safety threshold, set at construction time to prevent this
       //   from blowing up when unexpected winds produce small momentary
       //   free-stream velocities.
-      double L_over_V = Lref / (l_over_v_scale * fsv_mag);
+      double L_over_V = Lref / (static_cast<double>(l_over_v_scale) * fsv_mag);
       double body_rate_aero_frm[3];
       jeod::Vector3::transform( T_body_to_aero_frame,
                           environment.get_true_body_rates(),

--- a/models/tools/unit_test/models/tests/test_unit_framework.cc
+++ b/models/tools/unit_test/models/tests/test_unit_framework.cc
@@ -1,5 +1,9 @@
+#include <cstdlib>
+#include <exception>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "../include/unit_test.hh" 
+#include "mocks/cml/cml_message_mock.hh"
 
 // Create a test subclass to access protected methods (if needed)
 class UnitTestFrameworkTest : public UnitTestFramework {
@@ -19,7 +23,7 @@ TEST(UnitTestFrameworkTest, DefaultConstructorInitializesState) {
 }
 
 TEST(UnitTestFrameworkTest, ExpandEnvVariableKnown) {
-    setenv("MY_TEST_PATH", "/tmp/testdir", 1);  // POSIX-compatible
+    setenv("MY_TEST_PATH", "/tmp/testdir", 1);
     UnitTestFrameworkTest utf;
 
     std::string input = "${MY_TEST_PATH}/file.txt";
@@ -29,19 +33,17 @@ TEST(UnitTestFrameworkTest, ExpandEnvVariableKnown) {
 }
 
 TEST(UnitTestFrameworkTest, ExpandEnvVariableUnknownThrows) {
+    using testing::_;
+    using testing::HasSubstr;
+
+    CMLMessage::Mock cml_message_mock;
+
     unsetenv("NON_EXISTENT_VAR");
     UnitTestFrameworkTest utf;
 
+    EXPECT_CALL(
+        cml_message_mock,
+        publish(CMLMessage::Error, _, _, HasSubstr("'NON_EXISTENT_VAR' is not set")));
     std::string input = "${NON_EXISTENT_VAR}/file.txt";
-
-    try {
-        utf.expand_env_variables(input);
-        FAIL() << "Expected std::runtime_error due to missing environment variable";
-    } catch (const std::runtime_error& e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("NON_EXISTENT_VAR"), std::string::npos)
-            << "Error message should mention the missing variable name";
-    } catch (...) {
-        FAIL() << "Expected std::runtime_error but caught a different exception type";
-    }
+    EXPECT_THROW(utf.expand_env_variables(input), std::runtime_error);
 }

--- a/models/utilities/fault_management/include/fault_function.hh
+++ b/models/utilities/fault_management/include/fault_function.hh
@@ -44,6 +44,12 @@ class FaultFunctionBase : public Fault, public FaultFunctionParameter {
     FunctionType type; /* (--)
       The type of function to add to the fault variable. */
 
+// SWIG doesn't respect deleted copy constructors or assignment operators if you
+// include an instance of a class you're inheriting from as a member variable
+// without this guard.
+#ifdef SWIG
+%immutable;
+#endif
     // Periodic function parameters
     FaultFunctionParameter frequency; /* (--)
       The frequency of the periodic functions as a linear function of some
@@ -58,6 +64,9 @@ class FaultFunctionBase : public Fault, public FaultFunctionParameter {
       independent variable. Note: the model treats phase such that the model
       is cyclic with a phase shift of 1.0. The phase-offset represents the
       fraction of a period, not a measure of radians or degrees.*/
+#ifdef SWIG
+%mutable;
+#endif
 
   protected:
     double freq_int; /* (--)

--- a/models/utilities/table_interp_cpp/include/single_input_table_var_with_deriv.hh
+++ b/models/utilities/table_interp_cpp/include/single_input_table_var_with_deriv.hh
@@ -27,9 +27,18 @@
 class SingleInputTableVarDeriv : public GenericSingleInputTable
 {
  public:
+// SWIG doesn't respect deleted copy constructors or assignment operators if you
+// include an instance of a class you're inheriting from as a member variable
+// without this guard.
+#ifdef SWIG
+%immutable;
+#endif
   GenericSingleInputTable  derivs; /* (--)
     A parallel instance of GenericSingleInputTable used to manage the data
     for the first-derivative variable.*/
+#ifdef SWIG
+%mutable;
+#endif
   bool omit_derivative_vals; /* (--)
     Flag indicating whether this dual-data table is to be used to populate
     the first-derivative variables as well as the zeroth-derivative

--- a/utility/sanitizers/lsan.supp
+++ b/utility/sanitizers/lsan.supp
@@ -16,3 +16,4 @@ leak:*numpy*
 # Ignore other leaks that we can't do anything about.
 leak:vasprintf
 leak:libudunits*
+leak:jeod::*

--- a/utility/sanitizers/lsan.supp
+++ b/utility/sanitizers/lsan.supp
@@ -1,6 +1,7 @@
 # Ignore any leaks coming from Trick that we can't control.
 leak:Trick::DataRecordGroup::DataRecordGroup
 leak:Trick::FrameLog::default_data
+leak:Trick::MemoryManager::declare_var
 leak:Trick::MemoryManager::ref_attributes
 leak:Trick::MulticastGroup::MulticastGroup
 leak:Trick::UnitsMap::add_param


### PR DESCRIPTION
Get CML building and running on Rocky 9 in preparation for the Flight Sciences Lab (the runtime environment of most of our users) upgrading to Rocky 9 in September.

Issues resolved for Rocky 9:
- Somehow, a few cases in input files where a string was being assigned directly into a JEOD `NamedItem` were acceptable on Rocky 8 but not on Rocky 9. `name = "string"` &rarr; `name.set_name("string")`
- The `StateInitialize::generate_random` function explicitly casts the input seed to `result_type` to avoid potential signedness issues.
- Rewrote one of the stub unit tests to correctly catch messages and exceptions without leaking memory.
- Ignored a few more leak sources originating from code we can't control in LSAN outputs.
- Pre-addressed implicit enum to float conversions, which are deprecated in C++20. `float_type = enum_type` &rarr; `float_type = static_cast<double>(enum_type)`

Also addresses an issue in newer SWIG versions which arises when you inherit from a type but also include that type as a member of your class.

```cpp
class Base {
public:
    Base(const Base& other) = delete;
    Base& operator=(const Base& other) = delete;
};

class Derived : public Base {
public:
    Derived(const Derived& other) = delete;
    Derived& operator=(const Derived& other) = delete;

    Base instance; /* (--) SWIG issues here */
};
```
Even though we've deleted the copy constructor and copy assignment operator for the base and derived classes, SWIG still generates assignment interface code for `instance`, which causes a compiler error. We're seeing this on Fedora 44 and macOS, but we may as well get ahead of fixing it now. The solution is to surround the instances of `Base` with

```cpp
#ifdef SWIG
%immutable;
#endif
    Base instance;
#ifdef SWIG
%mutable;
#endif
```

The `%immutable` directive is a bit of a misnomer. It just prevents SWIG from generating `set_X` interface functions, it doesn't prevent calling member functions which mutate the type or setting data within that instance. So we're essentially just reinforcing what SWIG should already be recognizing, which is that the type is non-assignable.

Closes #31