### PR TITLE
Enable clang-tidy performance checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,9 @@
 #     To be added in a future pull request
 #
 # performance:
-#     To be added in a future pull request
+#     performance-enum-size:
+#         May enable in the future, but doesn't really buy us anything and might
+#         not play well with SWIG.
 #
 # portability:
 #     To be added in a future pull request
@@ -27,7 +29,9 @@
 #     To be added in a future pull request
 Checks: >
     clang-*,
-    -clang-analyzer-optin.performance.Padding
+        -clang-analyzer-optin.performance.Padding,
+    performance-*,
+        -performance-enum-size
 
 WarningsAsErrors: '*'
 

--- a/models/dynamics/actions/mass_body_detach_impulsive/include/mass_body_detach_impulsive.hh
+++ b/models/dynamics/actions/mass_body_detach_impulsive/include/mass_body_detach_impulsive.hh
@@ -70,8 +70,8 @@ class MassBodyDetachImpulsive : public jeod::BodyAction {
     void apply (jeod::DynManager & dyn_manager) override;
 
   protected:
-    virtual void apply_impulse( jeod::DynBody          & dyn_body,
-                                std::string  mass_point_name);
+    virtual void apply_impulse( jeod::DynBody     & dyn_body,
+                                const std::string &  mass_point_name);
 
   private:
     // not implemented

--- a/models/dynamics/actions/mass_body_detach_impulsive/src/mass_body_detach_impulsive.cc
+++ b/models/dynamics/actions/mass_body_detach_impulsive/src/mass_body_detach_impulsive.cc
@@ -165,8 +165,8 @@ MassBodyDetachImpulsive::apply( jeod::DynManager & dyn_manager)
 Purpose:(Applies an impulse at a MassPoint for parent and subject bodies)
 *******************************************************************************/
 void
-MassBodyDetachImpulsive::apply_impulse( jeod::DynBody          & dyn_body,
-                                        std::string  mass_point_name)
+MassBodyDetachImpulsive::apply_impulse( jeod::DynBody     & dyn_body,
+                                        const std::string & mass_point_name)
 {
   const jeod::MassPoint * mass_point = dyn_body.mass.find_mass_point(mass_point_name);
   if (mass_point == nullptr) {

--- a/models/dynamics/state_descriptors/extended_planetary_derived_state/include/point_to_point.hh
+++ b/models/dynamics/state_descriptors/extended_planetary_derived_state/include/point_to_point.hh
@@ -149,7 +149,7 @@ class PointToPointManager
   void add_point( const std::string & pt_name,
                   double      pt_pos[3],
                   std::list< PointToPointElement>  & element_list,
-                  std::string list_type);
+                  const std::string & list_type);
 
   // copy-constructor, operator= both declared private and unimplemented.
   PointToPointManager ( const PointToPointManager &);

--- a/models/dynamics/state_descriptors/extended_planetary_derived_state/src/point_to_point.cc
+++ b/models/dynamics/state_descriptors/extended_planetary_derived_state/src/point_to_point.cc
@@ -198,7 +198,7 @@ PointToPointManager::add_point(
   const std::string & pt_name,
   double pt_pos[3],
   std::list<PointToPointElement> & element_list,
-  std::string list_type)
+  const std::string & list_type)
 {
   // pt_pos is checked for NULL on the passthrough when creating the new
   // element.

--- a/models/dynamics/state_descriptors/separation_state/include/lvlh_separation_state.hh
+++ b/models/dynamics/state_descriptors/separation_state/include/lvlh_separation_state.hh
@@ -51,12 +51,12 @@ class LvlhSeparationState : public SeparationState
   explicit LvlhSeparationState(jeod::LvlhFrame & lvlh);
   ~LvlhSeparationState() override;
 
-  void initialize ( jeod::DynManager & dyn_manager,
-                    std::string planet_name,
-                    jeod::DynBody   & subject_body,
-                    jeod::DynBody   & source_body,
-                    std::string subject_name = "",
-                    std::string source_name = "");
+  void initialize ( jeod::DynManager  & dyn_manager,
+                    const std::string & planet_name,
+                    jeod::DynBody     & subject_body,
+                    jeod::DynBody     & source_body,
+                    const std::string & subject_name = "",
+                    const std::string & source_name = "");
 
   void initialize ( jeod::DynManager   & dyn_manager,
                     jeod::BasePlanet   & planet,

--- a/models/dynamics/state_descriptors/separation_state/src/lvlh_separation_state.cc
+++ b/models/dynamics/state_descriptors/separation_state/src/lvlh_separation_state.cc
@@ -66,12 +66,12 @@ NOTE - in SeparationState, the source-body identification was provided first.
        optional argument.
 *****************************************************************************/
 void
-LvlhSeparationState::initialize( jeod::DynManager & dyn_manager,
-                                 std::string planet_name,
-                                 jeod::DynBody   & subject_body,
-                                 jeod::DynBody   & source_body,
-                                 std::string subject_name,
-                                 std::string source_name)
+LvlhSeparationState::initialize( jeod::DynManager  & dyn_manager,
+                                 const std::string & planet_name,
+                                 jeod::DynBody     & subject_body,
+                                 jeod::DynBody     & source_body,
+                                 const std::string & subject_name,
+                                 const std::string & source_name)
 
 {
   if (!enabled) {

--- a/models/dynamics/state_descriptors/simple_planet_rel_state/include/simple_planet_rel_state.hh
+++ b/models/dynamics/state_descriptors/simple_planet_rel_state/include/simple_planet_rel_state.hh
@@ -32,8 +32,8 @@ class SimplePlanetRelState : public SubscriptionBase,
   double altitude;         /* (m) height of the frame-of-interest above the
                                   reference-height. */
 
-  SimplePlanetRelState(std::string body_frame_name_,
-                       std::string planet_frame_name);
+  SimplePlanetRelState(const std::string & body_frame_name_,
+                       const std::string & planet_frame_name);
 
   void initialize(jeod::DynBody & subject_body,
                           jeod::DynManager & dyn_manager) override;

--- a/models/dynamics/state_descriptors/simple_planet_rel_state/src/simple_planet_rel_state.cc
+++ b/models/dynamics/state_descriptors/simple_planet_rel_state/src/simple_planet_rel_state.cc
@@ -16,8 +16,8 @@ PROGRAMMERS:
 Constructor
 *****************************************************************************/
 SimplePlanetRelState::SimplePlanetRelState(
-     const std::string body_frame_name_,
-     const std::string planet_frame_name_)
+     const std::string & body_frame_name_,
+     const std::string & planet_frame_name_)
   :
   SubscriptionBase(),
   RelativeDerivedState(),

--- a/models/environment/atmos/atmosphere_models/DRWP_atmos/include/lookup_winds.hh
+++ b/models/environment/atmos/atmosphere_models/DRWP_atmos/include/lookup_winds.hh
@@ -193,9 +193,9 @@ public:
   void update(double altitude_in);
   void change_datafile_index(size_t index);
   bool change_profile();
-  bool load_DRWP_file(std::string  drwpFileName,
-                      bool         file_contains_vertical_wind_component,
-                      unsigned int wind_number);
+  bool load_DRWP_file(const std::string&  drwpFileName,
+                      bool                file_contains_vertical_wind_component,
+                      unsigned int        wind_number);
   void compute_average_wind();
   void compute_average_wind( size_t table_index);
   void compute_average_wind( double min_altitude,

--- a/models/environment/atmos/atmosphere_models/DRWP_atmos/src/lookup_winds.cc
+++ b/models/environment/atmos/atmosphere_models/DRWP_atmos/src/lookup_winds.cc
@@ -324,9 +324,9 @@ Note:
      within the file.
 *****************************************************************************/
 bool
-LookupAtmosWinds::load_DRWP_file( std::string  drwpFileName_,
-                                  bool         contains_vertical_component_,
-                                  unsigned int wind_number_)
+LookupAtmosWinds::load_DRWP_file( const std::string& drwpFileName_,
+                                  bool               contains_vertical_component_,
+                                  unsigned int       wind_number_)
 {
   if (!enabled) return false;
 

--- a/models/interactions/aero/include/aero_executive_table.hh
+++ b/models/interactions/aero/include/aero_executive_table.hh
@@ -170,7 +170,7 @@ public:
   ~AeroExecutiveTable() override = default;
 
   void change_table(unsigned int new_ix);
-  void change_table(std::string table_name);
+  void change_table(const std::string & table_name);
   void change_table(AeroTableSetBase & new_table);
   void add_table(AeroTableSetBase * new_table);
 

--- a/models/interactions/aero/include/aero_table_set_base.hh
+++ b/models/interactions/aero/include/aero_table_set_base.hh
@@ -151,7 +151,7 @@ protected:
   void query_aero_damping();
   void query_on_diag_aero_damping();
   void query_off_diag_aero_damping();
-  AeroDampingType verify_aero_damping(std::string type);
+  AeroDampingType verify_aero_damping(const std::string & type);
 
 private:
   // Make the copy constructor and assignment operator private

--- a/models/interactions/aero/src/aero_executive_table.cc
+++ b/models/interactions/aero/src/aero_executive_table.cc
@@ -106,7 +106,7 @@ AeroExecutiveTable::change_table( unsigned int new_ix)
 }
 /******************************************************************************/
 void
-AeroExecutiveTable::change_table( std::string new_name)
+AeroExecutiveTable::change_table( const std::string & new_name)
 {
   // Check trivial case - change commanded to current table.
   if (current_table != nullptr) {

--- a/models/interactions/aero/src/aero_table_set_base.cc
+++ b/models/interactions/aero/src/aero_table_set_base.cc
@@ -207,7 +207,7 @@ verify_aero_damping
 Purpose:()
 *******************************************************************************/
 AeroTableSetBase::AeroDampingType
-AeroTableSetBase::verify_aero_damping( std::string type)
+AeroTableSetBase::verify_aero_damping( const std::string & type)
 {
   if (coef_data_present) {
     if (!uncertainty_data_present) {

--- a/models/tools/unit_test/models/src/unit_test.cc
+++ b/models/tools/unit_test/models/src/unit_test.cc
@@ -699,7 +699,7 @@ UnitTestFramework::update_file()
   // If the user has specified titles in the data file, print them out
   if ( !titles.empty()) {
     if (!titles.front().empty()) {
-      std::cout << titles.front() << std::endl;
+      std::cout << titles.front() << '\n';
     }
     if (cycle_data) {
       titles.push_back(titles.front());

--- a/models/utilities/fault_management/include/fault_bias.hh
+++ b/models/utilities/fault_management/include/fault_bias.hh
@@ -57,7 +57,7 @@ Purpose:(Generic method for setting fault parameters. For this type of fault,
 *******************************************************************************/
 template<typename T>
 bool FaultBias<T>::set_param(const std::string& param_name, double value, bool) {
-  if (param_name.compare("bias") == 0) {
+  if (param_name == "bias") {
     bias = value;
   } else {
     return Fault::set_param(param_name, value);

--- a/models/utilities/fault_management/include/fault_manager.hh
+++ b/models/utilities/fault_management/include/fault_manager.hh
@@ -56,10 +56,7 @@ class FaultManager {
     };
     static const unsigned int Location_count = 5; /* (--)
       The number of possible Locations. INVALID doesn't count. */
-    static Location translate_location(const char* str);
-    static Location translate_location(const std::string& str) {
-      return translate_location(str.c_str());
-    }
+    static Location translate_location(const std::string& str);
 #endif
 
     ////    Operations    ////

--- a/models/utilities/fault_management/include/fault_random_walk.hh
+++ b/models/utilities/fault_management/include/fault_random_walk.hh
@@ -66,15 +66,15 @@ Purpose:(Generic method for setting fault parameters. For this type of fault,
 *******************************************************************************/
 template<typename T>
 bool FaultRandomWalk<T>::set_param(const std::string& param_name, double value, bool) {
-  if (param_name.compare("mean") == 0) {
+  if (param_name == "mean") {
     rand.mean = value;
-  } else if (param_name.compare("std_dev") == 0) {
+  } else if (param_name == "std_dev") {
     rand.std_dev = value;
-  } else if (param_name.compare("min") == 0) {
+  } else if (param_name == "min") {
     rand.lower_limit = value;
-  } else if (param_name.compare("max") == 0) {
+  } else if (param_name == "max") {
     rand.upper_limit = value;
-  } else if (param_name.compare("seed") == 0) {
+  } else if (param_name == "seed") {
     rand.seed = value;
   } else {
     return Fault::set_param(param_name, value);

--- a/models/utilities/fault_management/include/fault_white_noise.hh
+++ b/models/utilities/fault_management/include/fault_white_noise.hh
@@ -56,15 +56,15 @@ Purpose:(Generic method for setting fault parameters. For this type of fault,
 *******************************************************************************/
 template<typename T>
 bool FaultWhiteNoise<T>::set_param(const std::string& param_name, double value, bool) {
-  if (param_name.compare("mean") == 0) {
+  if (param_name == "mean") {
     noise.mean = value;
-  } else if (param_name.compare("std_dev") == 0) {
+  } else if (param_name == "std_dev") {
     noise.std_dev = value;
-  } else if (param_name.compare("min") == 0) {
+  } else if (param_name == "min") {
     noise.lower_limit = value;
-  } else if (param_name.compare("max") == 0) {
+  } else if (param_name == "max") {
     noise.upper_limit = value;
-  } else if (param_name.compare("seed") == 0) {
+  } else if (param_name == "seed") {
     noise.seed = value;
   } else {
     return Fault::set_param(param_name, value);

--- a/models/utilities/fault_management/include/trigger.hh
+++ b/models/utilities/fault_management/include/trigger.hh
@@ -15,6 +15,7 @@ PROGRAMMERS:
 #include <limits> // std::numeric_limits
 #include <cstring> // strcmp
 #include <cmath> // std::abs(), std::fmod(), std::max()
+#include <utility>
 #include "cml/models/utilities/cml_message/include/cml_message.hh"
 #include "cml/models/utilities/math_utils/include/math_utils.hh" // check_equal
 
@@ -241,7 +242,7 @@ template<> class Trigger<std::string> : public TriggerBase {
           "Cannot process an arithmetic value into a string.\n"
           "Assignment failed.\n");
       }
-    void set_value( std::string val) { value.assign(val);}
+    void set_value( std::string val) { value = std::move(val);}
   private:
     const std::string& variable; /* (--)
       The trigger string. Its value determines when the trigger is triggered. */

--- a/models/utilities/fault_management/include/trigger_group.hh
+++ b/models/utilities/fault_management/include/trigger_group.hh
@@ -32,7 +32,7 @@ class TriggerGroup {
 
     void add_trigger(TriggerBase& trigger);
 
-    bool set_trigger_enable(std::string trigger_name, bool enable_flag);
+    bool set_trigger_enable(const std::string& trigger_name, bool enable_flag);
 
     ////    Attributes    ////
 

--- a/models/utilities/fault_management/src/fault_manager.cc
+++ b/models/utilities/fault_management/src/fault_manager.cc
@@ -12,6 +12,7 @@ PROGRAMMERS:
 #include <cstdlib> // strtod, strtol, etc.
 #include <cstring> // strcmp
 #include <cmath>   // abs
+#include <unordered_map>
 #include <libxml/parser.h> // xmlParseFile, xmlNodePtr
 #include "cml/models/utilities/convert_string/include/convert_string.hh"
 
@@ -49,17 +50,18 @@ FaultManager::~FaultManager() {
 translate_location
 Purpose:(Translates a string into a Location.)
 *******************************************************************************/
-FaultManager::Location FaultManager::translate_location( const char* str) {
-  if (strcmp(str, "INIT") == 0) {
-    return Location::Initialize;
-  } else if (strcmp(str, "UPSTREAM") == 0) {
-    return Location::Upstream;
-  } else if (strcmp(str, "INTERMEDIATE_1") == 0) {
-    return Location::Intermediate_1;
-  } else if (strcmp(str, "INTERMEDIATE_2") == 0) {
-    return Location::Intermediate_2;
-  } else if (strcmp(str, "DOWNSTREAM") == 0) {
-    return Location::Downstream;
+FaultManager::Location FaultManager::translate_location(const std::string& str) {
+  static const std::unordered_map<std::string, Location> location_map {
+    {"INIT", Location::Initialize},
+    {"UPSTREAM", Location::Upstream},
+    {"INTERMEDIATE_1", Location::Intermediate_1},
+    {"INTERMEDIATE_2", Location::Intermediate_2},
+    {"DOWNSTREAM", Location::Downstream}
+  };
+
+  const auto location = location_map.find(str);
+  if (location != location_map.end()) {
+    return location->second;
   } else {
     return Location::INVALID;
   }

--- a/models/utilities/fault_management/src/trigger_group.cc
+++ b/models/utilities/fault_management/src/trigger_group.cc
@@ -47,13 +47,13 @@ set_trigger_enable
 Purpose:(Enables or disables a trigger in this group. If there are multiple
          triggers with the same name, they will be enabled/disabled together.)
 *******************************************************************************/
-bool TriggerGroup::set_trigger_enable( std::string trigger_name,
-                                       bool        enable_flag)
+bool TriggerGroup::set_trigger_enable( const std::string & trigger_name,
+                                       bool                enable_flag)
 {
   bool trigger_found = false;
-  for (auto& it : triggers) {
-    if (trigger_name.compare(it.second->name) == 0) {
-      it.first = enable_flag;
+  for (auto& [trigger_enabled, trigger] : triggers) {
+    if (trigger_name == trigger->name) {
+      trigger_enabled = enable_flag;
       trigger_found = true;
     }
   }

--- a/models/utilities/math_utils/include/math_utils.hh
+++ b/models/utilities/math_utils/include/math_utils.hh
@@ -94,7 +94,7 @@ public:
   // passed in, along with the size of 1 dimension of the array (e.g. 6x6 array
   // is sized "6").  An optional 5th argument allows processing a smaller
   // sub-matrix.
-  static bool cholesky_decomposition( std::string caller_id,
+  static bool cholesky_decomposition( const std::string & caller_id,
                                       const double * in_array,
                                       double * out_array,
                                       size_t size_in,

--- a/models/utilities/math_utils/src/math_utils.cc
+++ b/models/utilities/math_utils/src/math_utils.cc
@@ -646,7 +646,7 @@ Purpose:( Effectively takes the square root of a matrix such that
             enough to hold the generated array.)
 *******************************************************************************/
 bool
-MathUtils::cholesky_decomposition ( std::string origin,
+MathUtils::cholesky_decomposition ( const std::string & origin,
                                     const double * in_array,
                                     double * out_array,
                                     size_t   dimension_in,

--- a/models/utilities/table_interp_cpp/include/generic_multi_input_table.hh
+++ b/models/utilities/table_interp_cpp/include/generic_multi_input_table.hh
@@ -119,7 +119,7 @@ class GenericMultiInputTable
   virtual bool generate_output();
   bool precheck_output();
   void generate_trivial_output();
-  bool index_checks(size_t & idx1, size_t & idx2, std::string func);
+  bool index_checks(size_t & idx1, size_t & idx2, const std::string & func);
 
  private:
   bool load_data_internal_check( const SizeVec &dim_list );

--- a/models/utilities/table_interp_cpp/src/generic_multi_input_table.cc
+++ b/models/utilities/table_interp_cpp/src/generic_multi_input_table.cc
@@ -1019,7 +1019,7 @@ bool
 GenericMultiInputTable::index_checks(
         size_t & ix_start,
         size_t & ix_stop,
-        std::string func)
+        const std::string & func)
 {
   // Note - data_loaded implies data.size() > 0.
   if (!data_loaded) {

--- a/models/vehicle_management/compound_events/include/compound_event_manager.hh
+++ b/models/vehicle_management/compound_events/include/compound_event_manager.hh
@@ -61,15 +61,15 @@ class CompoundEventsManager : public VehicleEventsManager
   CompoundEvent& create_event();
   void add_trigger(WatchValuesBaseCore* new_trigger);
 
-  WatchValuesBaseCore * get_trigger(std::string name);
+  WatchValuesBaseCore * get_trigger(const std::string & name);
   void set_trigger_dbl_reference(WatchValuesBaseCore & trigger, double ref);
-  void set_trigger_dbl_reference(std::string name, double ref);
+  void set_trigger_dbl_reference(const std::string & name, double ref);
 
   // void set_trigger_comparison_logic(WatchValuesBaseCore * trigger, double ref);
   // void set_trigger_comparison_logic(std::string name, double ref);
 
   void set_trigger_delay_offset(WatchValuesBaseCore & trigger, double ref);
-  void set_trigger_delay_offset(std::string name, double ref);
+  void set_trigger_delay_offset(const std::string & name, double ref);
 
   template <typename T>
   EventTrigger<T>& create_trigger(const T & var,

--- a/models/vehicle_management/compound_events/src/compound_event_manager.cc
+++ b/models/vehicle_management/compound_events/src/compound_event_manager.cc
@@ -121,7 +121,7 @@ Purpose:
   Returns a trigger based on its name.
 *****************************************************************************/
 WatchValuesBaseCore *
-CompoundEventsManager::get_trigger(std::string name)
+CompoundEventsManager::get_trigger(const std::string & name)
 {
   auto it = std::find_if( managed_triggers.begin(), managed_triggers.end(),
                           [name](WatchValuesBaseCore * trigger_) {
@@ -152,7 +152,7 @@ CompoundEventsManager::set_trigger_dbl_reference(
 /****************************************************************************/
 void
 CompoundEventsManager::set_trigger_dbl_reference(
-  std::string name,
+  const std::string & name,
   double ref)
 {
   WatchValuesBaseCore * trigger = CompoundEventsManager::get_trigger(name);
@@ -191,7 +191,7 @@ CompoundEventsManager::set_trigger_delay_offset(
 /****************************************************************************/
 void
 CompoundEventsManager::set_trigger_delay_offset(
-  std::string name,
+  const std::string & name,
   double ref)
 {
   WatchValuesBaseCore * trigger = CompoundEventsManager::get_trigger(name);


### PR DESCRIPTION
Eliminate unnecessary copies and replace `string.compare` with `string ==`.

Closes #65